### PR TITLE
Fix case when OS regex exists at position 0 of the OS string in RbConfig

### DIFF
--- a/lib/listen/adapters/darwin.rb
+++ b/lib/listen/adapters/darwin.rb
@@ -52,7 +52,7 @@ module Listen
       # @return [Boolean] whether usable or not
       #
       def self.usable?
-        return false unless RbConfig::CONFIG['target_os'] =~ /darwin(1.+)?$/i
+        return false unless /darwin(1.+)?$/i.match(RbConfig::CONFIG['target_os'])
 
         require 'rb-fsevent'
         true

--- a/lib/listen/adapters/linux.rb
+++ b/lib/listen/adapters/linux.rb
@@ -63,7 +63,7 @@ module Listen
       # @return [Boolean] whether usable or not
       #
       def self.usable?
-        return false unless RbConfig::CONFIG['target_os'] =~ /linux/i
+        return false unless /linux/i.match(RbConfig::CONFIG['target_os'])
 
         require 'rb-inotify'
         true

--- a/lib/listen/adapters/windows.rb
+++ b/lib/listen/adapters/windows.rb
@@ -47,7 +47,7 @@ module Listen
       # @return [Boolean] whether usable or not
       #
       def self.usable?
-        return false unless RbConfig::CONFIG['target_os'] =~ /mswin|mingw/i
+        return false unless /mswin|mingw/i.match(RbConfig::CONFIG['target_os'])
 
         require 'rb-fchange'
         true


### PR DESCRIPTION
This fixes Issue #33.

The style might not be that great, maybe it could look nicer I don't do much Ruby, but it works!
