### PR TITLE
Use lstat instead of stat when calculating mtime

### DIFF
--- a/lib/listen/directory_record.rb
+++ b/lib/listen/directory_record.rb
@@ -312,7 +312,7 @@ module Listen
     # @return [Fixnum, Float] the mtime of the file
     #
     def mtime_of(file)
-      File.mtime(file).send(HIGH_PRECISION_SUPPORTED ? :to_f : :to_i)
+      File.lstat(file).mtime.send(HIGH_PRECISION_SUPPORTED ? :to_f : :to_i)
     end
   end
 end

--- a/spec/listen/directory_record_spec.rb
+++ b/spec/listen/directory_record_spec.rb
@@ -1103,5 +1103,36 @@ describe Listen::DirectoryRecord do
         }.should_not raise_error(Errno::ENOENT)
       end
     end
+
+    context 'with symlinks' do
+      it 'looks at symlinks not their targets' do
+        fixtures do |path|
+          touch 'target'
+          symlink 'target', 'symlink'
+
+          record = described_class.new(path)
+          record.build
+
+          sleep 1
+          touch 'target'
+
+          record.fetch_changes([path], :relative_paths => true)[:modified].should == ['target']
+        end
+      end
+
+      it 'handles broken symlinks' do
+        fixtures do |path|
+          symlink 'target', 'symlink'
+
+          record = described_class.new(path)
+          record.build
+
+          sleep 1
+          rm 'symlink'
+          symlink 'new-target', 'symlink'
+          record.fetch_changes([path], :relative_paths => true)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Prevents an exception when getting the mtime of a broken symlink.
