### PR TITLE
Remove hardcoded platform specific dependencies.

### DIFF
--- a/listen.gemspec
+++ b/listen.gemspec
@@ -15,10 +15,6 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project = 'listen'
 
-  s.add_dependency 'rb-fsevent', '~> 0.9.1'
-  s.add_dependency 'rb-inotify', '~> 0.8.8'
-  s.add_dependency 'rb-fchange', '~> 0.0.5'
-
   s.add_development_dependency 'bundler'
 
   s.files        = Dir.glob('{lib}/**/*') + %w[CHANGELOG.md LICENSE README.md]


### PR DESCRIPTION
Hi,

This gem works independently of its dependencies. Is not good idea to force people on some platform to install other platform specific code. More over, it explodes the amount of gems I need on my system, it pollutes my load path as is shown in example bellow and as least but not last, it makes packaging for Linux distribution pain. Thank you for consideration.

```
irb
irb(main):001:0> puts $:
/usr/local/share/ruby/site_ruby
/usr/local/lib64/ruby/site_ruby
/usr/share/ruby/vendor_ruby
/usr/lib64/ruby/vendor_ruby
/usr/share/rubygems
/usr/share/ruby
/usr/lib64/ruby
=> nil
irb(main):002:0> require 'listen'
=> true
irb(main):003:0> puts $:
/home/vondruch/gem_home/listen/gems/rb-fsevent-0.9.1/lib
/usr/share/gems/gems/ffi-1.0.9/lib
/usr/share/gems/gems/ffi-1.0.9/ext
/usr/lib64/gems/exts/ffi-1.0.9/lib
/home/vondruch/gem_home/listen/gems/rb-inotify-0.8.8/lib
/home/vondruch/gem_home/listen/gems/rb-fchange-0.0.5/lib
/home/vondruch/gem_home/listen/gems/listen-0.4.7/lib
/usr/local/share/ruby/site_ruby
/usr/local/lib64/ruby/site_ruby
/usr/share/ruby/vendor_ruby
/usr/lib64/ruby/vendor_ruby
/usr/share/rubygems
/usr/share/ruby
/usr/lib64/ruby
=> nil
```
