### PR TITLE
ENXIO raised when hashing UNIX domain socket file

### DIFF
--- a/lib/listen/directory_record.rb
+++ b/lib/listen/directory_record.rb
@@ -282,7 +282,7 @@ module Listen
     #
     def sha1_checksum(path)
       Digest::SHA1.file(path).to_s
-    rescue Errno::EACCES, Errno::ENOENT
+    rescue Errno::EACCES, Errno::ENOENT, Errno::ENXIO
       nil
     end
 

--- a/spec/listen/directory_record_spec.rb
+++ b/spec/listen/directory_record_spec.rb
@@ -1161,6 +1161,16 @@ describe Listen::DirectoryRecord do
       end
     end
 
+    context 'within a directory containing a unix domain socket file' do
+      it 'does not raise an exception when hashing a unix domain socket file' do
+        fixtures do |path|
+          require 'socket'
+          UNIXServer.new('unix_domain_socket.sock')
+          lambda { changes(path){} }.should_not raise_error(Errno::ENXIO)
+        end
+      end
+    end
+
     context 'with symlinks', :unless => windows? do
       it 'looks at symlinks not their targets' do
         fixtures do |path|


### PR DESCRIPTION
This commit fixes the error and adds a spec example to reproduce the issue. :cake:

I tried several times to fix the rbx-19mode failure reported by Travis, but no cigar. :bomb: 

Please fix my test for me, since you know your test harness better than I do. :pill:

Cheers.
