### PR TITLE
fix ruby warning in adapter.rb

### DIFF
--- a/lib/listen/adapter.rb
+++ b/lib/listen/adapter.rb
@@ -166,7 +166,7 @@ module Listen
     def self.works?(directory, options = {})
       work = false
       test_file = "#{directory}/.listen_test"
-      callback = lambda { |changed_dirs, options| work = true }
+      callback = lambda { |*| work = true }
       adapter  = self.new(directory, options, &callback)
       adapter.start(false)
 


### PR DESCRIPTION
While digging through the source of your Gem I noticed that my Editor was displaying the following warning after linting caused by outter variable shadowing in the `adapter.rb` file. 

```
adapter.rb:169: warning: shadowing outer local variable - options
```

This pull requests fixes this.
