### PR TITLE
Default high precision off if the mtime call fails

### DIFF
--- a/lib/listen/directory_record.rb
+++ b/lib/listen/directory_record.rb
@@ -18,7 +18,11 @@ module Listen
     # Defines the used precision based on the type of mtime returned by the
     # system (whether its in milliseconds or just seconds)
     #
-    HIGH_PRECISION_SUPPORTED = File.mtime(__FILE__).to_f.to_s[-2..-1] != '.0'
+    begin
+      HIGH_PRECISION_SUPPORTED = File.mtime(__FILE__).to_f.to_s[-2..-1] != '.0'
+    rescue
+      HIGH_PRECISION_SUPPORTED = false
+    end
 
     # Data structure used to save meta data about a path
     #


### PR DESCRIPTION
This is a bit of an edge case. When using the gem under JRuby inside a JAR on Windows, the mtime call fails with SystemCallError unknown error 20047.

I assume that this is because it's run under a JAR archive and Windows does something different from OSX that makes the mtime call fail. It works fine under OSX, and I imagine Linux as well.

Since it's a bit of an edge case, and the alternative I see is to hook it into the listen test in `works?`, I figured it's better to just default to high precision not being available if it errors.
