### PR TITLE
Move adapter dependencies to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,6 @@ gemspec
 
 gem 'rake'
 
-gem 'rb-kqueue', '~> 0.2' if RbConfig::CONFIG['target_os'] =~ /freebsd/i
-gem 'rb-fsevent', '~> 0.9.1' if RbConfig::CONFIG['target_os'] =~ /darwin(1.+)?$/i
-gem 'rb-inotify', '~> 0.9.0' if RbConfig::CONFIG['target_os'] =~ /linux/i
-gem 'wdm',        '~> 0.0.3' if RbConfig::CONFIG['target_os'] =~ /mswin|mingw/i
-
 group :development do
   platform :ruby do
     gem 'coolline'

--- a/listen.gemspec
+++ b/listen.gemspec
@@ -15,6 +15,11 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project = 'listen'
 
+  s.add_dependency 'rb-kqueue',  '~> 0.2'   if RbConfig::CONFIG['target_os'] =~ /freebsd/i
+  s.add_dependency 'rb-fsevent', '~> 0.9.1' if RbConfig::CONFIG['target_os'] =~ /darwin(1.+)?$/i
+  s.add_dependency 'rb-inotify', '~> 0.9.0' if RbConfig::CONFIG['target_os'] =~ /linux/i
+  s.add_dependency 'wdm',        '~> 0.0.3' if RbConfig::CONFIG['target_os'] =~ /mswin|mingw/i
+
   s.add_development_dependency 'bundler'
 
   s.files        = Dir.glob('{lib}/**/*') + %w[CHANGELOG.md LICENSE README.md]


### PR DESCRIPTION
I think that this gem would provide a lot more utility if it automatically installed the appropriate adapter. For instance, I use Linux. I want rb-inotify installed automatically. This happens if you clone the repository and `bundle install`, but not if you install the gem. The gemspec should contain the adapters--not the Gemfile. The Gemfile should be for project development, and the gemspec should tell projects utilizing the gem what its requirements are.  See [Clarifying the Roles of the .gemspec and Gemfile](http://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/) by @wycats.

The side effect is that I have to put `gem 'rb-inotify', '~>0.8.8'` in my own Gemfile so it will be available to guard. Since listen is the only gem that uses it, I think it's incorrect for me to be responsible for maintaining the dependency.

Thanks! :heart: guard!

Justin
