### PR TITLE
Allow array of directories as input

### DIFF
--- a/lib/listen/multi_listener.rb
+++ b/lib/listen/multi_listener.rb
@@ -19,7 +19,7 @@ module Listen
     #
     def initialize(*args, &block)
       options     = args.last.is_a?(Hash) ? args.pop : {}
-      directories = args
+      directories = args.flatten
 
       @block               = block
       @directories         = directories.map  { |d| Pathname.new(d).realpath.to_s }


### PR DESCRIPTION
All the directories to listen have to be passed as individual args.  

In case user wanted to read a list of directories from a config file and listen, he would typically load those directories as an array.  However, I can't pass the array of dirs.

Listen.to(["/dir/to/listen/to/one", "/dir/to/listen/to/two"])

To allow this, we just have to flatten the args.  This would keep the code backward compatibile and at the same time allow array to be supplied.
