### PR TITLE
unable to load listen with ActiveSupport 4.0.0-beta1

### DIFF
--- a/lib/listen/adapter.rb
+++ b/lib/listen/adapter.rb
@@ -184,14 +184,14 @@ module Listen
     # @return [Boolean] whether usable or not
     #
     def self.usable?
-      load_dependency if RbConfig::CONFIG['target_os'] =~ target_os_regex
+      load_dependent_adapter if RbConfig::CONFIG['target_os'] =~ target_os_regex
     end
 
     # Load the adapter gem
     #
     # @return [Boolean] whether required or not
     #
-    def self.load_dependency
+    def self.load_dependent_adapter
       @loaded ||= require adapter_gem
     end
 

--- a/lib/listen/adapters/windows.rb
+++ b/lib/listen/adapters/windows.rb
@@ -29,7 +29,7 @@ module Listen
       #
       # @return [Boolean] whether required or not
       #
-      def self.load_dependency
+      def self.load_dependent_adapter
         super
       rescue Gem::LoadError
         Kernel.warn BUNDLER_DECLARE_GEM


### PR DESCRIPTION
On ActiveSupport 4.0 environment, Listen isn't work correctly.
I think that reasons is below.

Listen::Adapter.load_dependency is conflicted with ActiveSupport::Dependencies::Loadable.load_dependency.

I renamed Adapter.load_dependency to load_dependent_adapter, and it seems work fine.
