### PR TITLE
Kill poller_thread before waiting for it to die

### DIFF
--- a/lib/listen/adapter.rb
+++ b/lib/listen/adapter.rb
@@ -113,7 +113,10 @@ module Listen
 
       worker.stop if worker
       Thread.kill(worker_thread) if worker_thread
-      poller_thread.join if poller_thread
+      if poller_thread
+        poller_thread.kill
+        poller_thread.join
+      end
     end
 
     # Pauses the adapter.


### PR DESCRIPTION
I noticed that recent guard versions sometimes fail to exit if there's a poller thread running: If so, it'll just hang on exit after saying "INFO - Bye bye...". When Ctrl-C'ing that, it will return you to the REPL and quitting immediately afterwards (via "quit") works. 

I tracked this problem down to the listen adapter waiting for a poller thread to quit without actually telling it to terminate.

This patch kills the poller thread before joining the thread, which makes guard reliably exit. I hope you'll consider including this in a release (-:
