### PR TITLE
Fix jruby error on Pathname#relative_path_from

### DIFF
--- a/lib/listen/directory_record.rb
+++ b/lib/listen/directory_record.rb
@@ -190,9 +190,15 @@ module Listen
     # @return [String] the relative path
     #
     def relative_to_base(path)
-      path = path.force_encoding("BINARY") if path.respond_to?(:force_encoding)
-      relative_path = Pathname.new(path).relative_path_from(Pathname.new directory).to_s
-      relative_path unless relative_path.start_with?('..')
+      path = path.dup
+      regexp = "\\A#{Regexp.quote directory}(#{File::SEPARATOR}|\\z)"
+      if path.respond_to?(:force_encoding)
+        path.force_encoding("BINARY")
+        regexp.force_encoding("BINARY")
+      end
+      if path.sub!(Regexp.new(regexp), '')
+        path
+      end
     end
 
     private


### PR DESCRIPTION
My fault on https://github.com/guard/listen/pull/115

Go back to the regexp substitution and force both path and directory encodings before substitution.

The regexp is a bit different (need more specs?):
- `^` match line begin, should be `\A` for string begin
- `#{File::SEPARATOR}?` may get path "/ab" recognized as "b" under directory "/a"
