### PR TITLE
Prevent polling just because the adapter gem was already required

### DIFF
--- a/lib/listen/adapter.rb
+++ b/lib/listen/adapter.rb
@@ -192,10 +192,12 @@ module Listen
 
     # Load the adapter gem
     #
-    # @return [Boolean] whether required or not
+    # @return [Boolean] whether loaded or not
     #
     def self.load_dependent_adapter
-      @loaded ||= require adapter_gem
+      return true if @loaded
+      require adapter_gem
+      return @loaded = true
     end
 
     # Runs a tests to determine if the adapter can actually pick up

--- a/spec/listen/adapter_spec.rb
+++ b/spec/listen/adapter_spec.rb
@@ -72,6 +72,15 @@ describe Listen::Adapter do
     end
   end
 
+  describe '.load_dependend_adapter' do
+    it 'returns true (success) even if the adapter_gem has already been required' do
+      described_class.stub(:adapter_gem => 'already_loaded_gem')
+      described_class.stub(:require => false)
+
+      described_class.load_dependent_adapter.should be_true
+    end
+  end
+
   Listen::Adapter::OPTIMIZED_ADAPTERS.each do |adapter|
     adapter_class = Listen::Adapters.const_get(adapter)
     if adapter_class.usable?


### PR DESCRIPTION
Listen::Adapter.load_dependend_adapter returns true even if already loaded.  Otherwise, if (for example) `gem "rb-fsevent"` already appears in a Gemfile or some other gem requires the adapter_gem before we do, Listen will always fall back to polling.

Any thoughts on this approach of fixing the problem?
