### PR TITLE
relative_paths now defaults to false (issue #131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,7 @@
 
 - [#98][] New method: `Listen.to!` which blocks the current thread. ([@rymai][])
 - [#98][] New method: `Listen::Listener#start!` to start the listener and block the current thread. ([@martikaljuve][] & [@rymai][])
-- [#95][] Make `Listen::Listener` capable of listening to multiple directories, deprecates `Listen::MultiListener`. ([@rymai][])
+- [#95][] Make `Listen::Listener` capable of listening to multiple directories, deprecates `Listen::MultiListener`, defaults `Listener#relative_paths` to `true` when listening to a single directory (see [#131][]). ([@rymai][])
 - [#85][] Compute the SHA1 sum only for regular files. ([@antifuchs][])
 - New methods: `Listen::Adapter#pause`, `Listen::Adapter#unpause` and `Listen::Adapter#paused?`. ([@rymai][])
 - Refactor `Listen::DirectoryRecord` internals. ([@rymai][])

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -272,7 +272,7 @@ module Listen
       if directories.size > 1 && options[:relative_paths]
         Kernel.warn "[Listen warning]: #{RELATIVE_PATHS_WITH_MULTIPLE_DIRECTORIES_WARNING_MESSAGE}"
       end
-      @use_relative_paths = directories.one? && options.delete(:relative_paths) { true }
+      @use_relative_paths = directories.one? && options.delete(:relative_paths) { false }
     end
 
     # Build the directory record concurrently and initialize the adapter.

--- a/spec/listen/adapters/polling_spec.rb
+++ b/spec/listen/adapters/polling_spec.rb
@@ -12,7 +12,7 @@ describe Listen::Adapters::Polling do
   end
 
   describe '#poll' do
-    let(:listener) { mock(Listen::Listener) }
+    let(:listener) { double(Listen::Listener) }
     let(:callback) { lambda { |changed_directories, options| @called = true; listener.on_change(changed_directories, options) } }
 
     after { subject.stop }

--- a/spec/listen/directory_record_spec.rb
+++ b/spec/listen/directory_record_spec.rb
@@ -1201,7 +1201,7 @@ describe Listen::DirectoryRecord do
           lambda {
             touch 'removed_file.txt'
             changes(path) { touch 'removed_file.txt' }
-          }.should_not raise_error(Errno::ENOENT)
+          }.should_not raise_error
         end
       end
     end
@@ -1211,7 +1211,7 @@ describe Listen::DirectoryRecord do
         fixtures do |path|
           require 'socket'
           UNIXServer.new('unix_domain_socket.sock')
-          lambda { changes(path){} }.should_not raise_error(Errno::ENXIO)
+          lambda { changes(path){} }.should_not raise_error
         end
       end
     end

--- a/spec/listen_spec.rb
+++ b/spec/listen_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Listen do
   describe '#to' do
-    let(:listener)       { mock(Listen::Listener) }
+    let(:listener)       { double(Listen::Listener) }
     let(:listener_class) { Listen::Listener }
     before { listener_class.stub(:new => listener) }
 

--- a/spec/support/adapter_helper.rb
+++ b/spec/support/adapter_helper.rb
@@ -120,7 +120,7 @@ end
 
 shared_examples_for 'an adapter that call properly listener#on_change' do |*args|
   options = (args.first && args.first.is_a?(Hash)) ? args.first : {}
-  let(:listener) { mock(Listen::Listener) }
+  let(:listener) { double(Listen::Listener) }
   before { described_class.stub(:works?) { true } }
 
   context 'single file operations' do


### PR DESCRIPTION
- Fix issue #131 - `Listener#relative_paths` now defaults to `false`, and added a mention of the errant change to the Changelog for v1.0.0
- Fixed minor mistake in the relevant spec (using `watched_directories` when should have been using `watched_directory` and tried to improve code to make similar mistakes more difficult to make.
- Replace deprecated `mock` with new `double`, and fixed deprecated usage of `raise_error(SPECIFIC_ERROR_CLASS)` (see https://github.com/rspec/rspec-expectations/issues/231)
