### PR TITLE
Remove Celluloid core detection

### DIFF
--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -116,9 +116,8 @@ module Listen
     end
 
     def _init_actors
-      cores = Celluloid.cores || 2
       Celluloid::Actor[:listen_silencer]    = Silencer.new(options)
-      Celluloid::Actor[:listen_change_pool] = Change.pool(size: cores, args: self)
+      Celluloid::Actor[:listen_change_pool] = Change.pool(args: self)
       Celluloid::Actor[:listen_adapter]     = Adapter.new(self)
       Celluloid::Actor[:listen_record]      = Record.new(self)
     end

--- a/spec/lib/listen/listener_spec.rb
+++ b/spec/lib/listen/listener_spec.rb
@@ -74,7 +74,7 @@ describe Listen::Listener do
     end
 
     it "registers change_pool" do
-      expect(Listen::Change).to receive(:pool).with(size: 1, args: listener) { change_pool }
+      expect(Listen::Change).to receive(:pool).with(args: listener) { change_pool }
       expect(Celluloid::Actor).to receive(:[]=).with(:listen_change_pool, change_pool)
       listener.start
     end


### PR DESCRIPTION
This replicates celluloid logic and is broken in the current state.

Fixes #142.
