### PR TITLE
Proper Regex for ignored directories

### DIFF
--- a/lib/listen/silencer.rb
+++ b/lib/listen/silencer.rb
@@ -35,7 +35,7 @@ module Listen
 
     def _default_ignored_directories_patterns
       ignored_directories = DEFAULT_IGNORED_DIRECTORIES.map { |d| Regexp.escape(d) }
-      %r{(?:#{ignored_directories.join('|')})/}
+      %r{/(?:#{ignored_directories.join('|')})(/|$)}
     end
 
     def _default_ignored_extensions_patterns

--- a/spec/lib/listen/silencer_spec.rb
+++ b/spec/lib/listen/silencer_spec.rb
@@ -9,26 +9,38 @@ describe Listen::Silencer do
 
     context "default ignore" do
       Listen::Silencer::DEFAULT_IGNORED_DIRECTORIES.each do |dir|
-        let(:path) { pwd.join(dir) }
+        describe do
+          let(:path) { pwd.join(dir) }
 
-        it "silences default ignored directory: #{dir}" do
-          expect(silencer.silenced?(path)).to be_true
-        end
+          it "silences default ignored directory: #{dir}" do
+            expect(silencer.silenced?(path)).to be_true
+          end
 
-        context "with a directory just containing the same name" do
-          let(:path) { pwd.join("#{dir}foo") }
+          context "with a directory beginning with the same name" do
+            let(:path) { pwd.join("#{dir}foo") }
 
-          it "doesn't silences default ignored directory: #{dir}foo" do
-            expect(silencer.silenced?(path)).to be_false
+            it "doesn't silences default ignored directory: #{dir}foo" do
+              expect(silencer.silenced?(path)).to be_false
+            end
+          end
+
+          context "with a directory ending with the same name" do
+            let(:path) { pwd.join("foo#{dir}") }
+
+            it "doesn't silences default ignored directory: foo#{dir}" do
+              expect(silencer.silenced?(path)).to be_false
+            end
           end
         end
       end
 
       Listen::Silencer::DEFAULT_IGNORED_EXTENSIONS.each do |extension|
-        let(:path) { pwd.join(extension) }
+        describe do
+          let(:path) { pwd.join(extension) }
 
-        it "silences default ignored extension: #{extension}" do
-          expect(silencer.silenced?(path)).to be_true
+          it "silences default ignored extension: #{extension}" do
+            expect(silencer.silenced?(path)).to be_true
+          end
         end
       end
     end


### PR DESCRIPTION
This should properly address #144.

With the `let` definition not in a `describe` block, the `path`
variable would have the same value for every `it`
block inside the `.each` loops...

Also, handle cases where the a directory ends with am ignored folder name.
