### PR TITLE
Properly quit Listen when receiving the INT signal

### DIFF
--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -139,7 +139,7 @@ module Listen
       _terminate_celluloid_actors
       exit
     rescue => ex
-      Kernel.warn "[Listen warning]: Change block raise an execption: #{$!}"
+      Kernel.warn "[Listen warning]: Change block raised an exception: #{$!}"
       Kernel.warn "Backtrace:\n\t#{ex.backtrace.join("\n\t")}"
     end
 

--- a/spec/acceptance/listen_spec.rb
+++ b/spec/acceptance/listen_spec.rb
@@ -13,7 +13,13 @@ describe "Listen" do
     @listener = setup_listener(options, callback)
     @listener.start
   }
-  after { listener.stop }
+  after {
+    begin
+      listener.stop
+    rescue SystemExit
+      # ignore the SystemExit error from the thread
+    end
+  }
 
   context "with one listen dir" do
     let(:paths) { Pathname.new(Dir.pwd) }
@@ -23,7 +29,7 @@ describe "Listen" do
       let(:callback) { ->(x,y,z) { raise 'foo' } }
 
       it "warns the backtrace" do
-        expect(Kernel).to receive(:warn).with("[Listen warning]: Change block raise an execption: foo")
+        expect(Kernel).to receive(:warn).with("[Listen warning]: Change block raised an exception: foo")
         expect(Kernel).to receive(:warn).with(/^Backtrace:.*/)
         listen { touch 'file.rb' }
       end

--- a/spec/lib/listen/listener_spec.rb
+++ b/spec/lib/listen/listener_spec.rb
@@ -126,34 +126,11 @@ describe Listen::Listener do
   end
 
   describe "#stop" do
-    let(:thread) { double(kill: true) }
-    before {
-      Celluloid::Actor.stub(:kill)
-      listener.stub(:thread) { thread }
-    }
+    let(:thread) { double(join: true) }
+    before { listener.stub(:thread) { thread } }
 
-    it "kills thread" do
-      expect(thread).to receive(:kill)
-      listener.stop
-    end
-
-    it "terminates silencer" do
-      expect(silencer).to receive(:terminate)
-      listener.stop
-    end
-
-    it "kills adapter" do
-      expect(Celluloid::Actor).to receive(:kill).with(adapter)
-      listener.stop
-    end
-
-    it "terminates change_pool" do
-      expect(change_pool).to receive(:terminate)
-      listener.stop
-    end
-
-    it "terminates record" do
-      expect(record).to receive(:terminate)
+    it "joins thread" do
+      expect(thread).to receive(:join)
       listener.stop
     end
   end

--- a/spec/lib/listen_spec.rb
+++ b/spec/lib/listen_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Listen do
   describe '#to' do
-    it "initalizes listner" do
+    it "initalizes listener" do
       expect(Listen::Listener).to receive(:new).with('/path')
       described_class.to('/path')
     end


### PR DESCRIPTION
Calling `exit` does not stop Listen in a clean way, that's
causing a very long exit. Celluloid actors cannot be
terminated in a trap block so we cannot call `#stop` inside
the trap block.
The trick is to simply call `#stop` which now only sets an instance
variable to let the thread know that it should exit its
loop and wait for the thread to exit.
The thread then exit its loop, then terminate Celluloid actors cleanly
and exit itself.

I believe it fixes #146.

@thibaudgg, @nex3 what do you guys think of this solution?
