### PR TITLE
Add wait_for_delay option

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ ignore!: %r{/foo/bar}                           # Same as ignore options, but ov
 latency: 0.5                                    # Set the delay (**in seconds**) between checking for changes
                                                 # default: 0.25 sec (1.0 sec for polling)
 
+wait_for_delay: 4                               # Set the delay (**in seconds**) between calls to the callback when changes exist
+                                                # default: 0.10 sec
+
 force_polling: true                             # Force the use of the polling adapter
                                                 # default: none
 

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -100,6 +100,7 @@ module Listen
     def _init_options(options = {})
       { debug: false,
         latency: nil,
+        wait_for_delay: 0.1,
         force_polling: false,
         polling_fallback_message: nil }.merge(options)
     end
@@ -134,7 +135,7 @@ module Listen
         unless changes.all? { |_,v| v.empty? }
           block.call(changes[:modified], changes[:added], changes[:removed])
         end
-        sleep 0.1
+        sleep options[:wait_for_delay]
       end
 
       _terminate_actors

--- a/spec/lib/listen/listener_spec.rb
+++ b/spec/lib/listen/listener_spec.rb
@@ -37,15 +37,17 @@ describe Listen::Listener do
       expect(listener.options).to eq({
         debug: false,
         latency: nil,
+        wait_for_delay: 0.1,
         force_polling: false,
         polling_fallback_message: nil })
     end
 
     it "sets new options on initialize" do
-      listener = Listen::Listener.new('lib', latency: 1.234)
+      listener = Listen::Listener.new('lib', latency: 1.234, wait_for_delay: 0.85)
       expect(listener.options).to eq({
         debug: false,
         latency: 1.234,
+        wait_for_delay: 0.85,
         force_polling: false,
         polling_fallback_message: nil })
     end


### PR DESCRIPTION
Resolves issue #156

This is totally separate issue but have to note that I was able to successfully run unit tests (even without my changes) only on 1 computer out of 3. And on the second one after increasing sleep time in the `acceptence_helper.rb` file. 
