### PR TITLE
Fixes the #silenced? method when "only" patterns are present

### DIFF
--- a/lib/listen/silencer.rb
+++ b/lib/listen/silencer.rb
@@ -19,7 +19,7 @@ module Listen
     def silenced?(path)
       if only_patterns
         p path
-        !only_patterns.all? { |pattern| _relative_path(path) =~ pattern }
+        !only_patterns.any? { |pattern| _relative_path(path) =~ pattern }
       else
         ignore_patterns.any? { |pattern| _relative_path(path) =~ pattern }
       end

--- a/spec/lib/listen/silencer_spec.rb
+++ b/spec/lib/listen/silencer_spec.rb
@@ -92,20 +92,25 @@ describe Listen::Silencer do
     end
 
     context "with only options (array)" do
-      let(:options) { { only: [%r{foo}, %r{.txt$}] } }
+      let(:options) { { only: [%r{^foo/}, %r{\.txt$}] } }
 
       it "doesn't silence good directory" do
-        path = pwd.join('foo')
+        path = pwd.join('foo/bar.rb')
         expect(silencer.silenced?(path)).to be_false
       end
 
       it "doesn't silence good file" do
-        path = pwd.join('foo/bar.txt')
+        path = pwd.join('bar.txt')
         expect(silencer.silenced?(path)).to be_false
       end
 
       it "silences other directory" do
-        path = pwd.join('bar.txt')
+        path = pwd.join('bar/baz.rb')
+        expect(silencer.silenced?(path)).to be_true
+      end
+
+      it "silences other file" do
+        path = pwd.join('bar.rb')
         expect(silencer.silenced?(path)).to be_true
       end
     end


### PR DESCRIPTION
As soon as a path is matched against an "only" regexp, it's
not silenced, so it's silenced if it doesn't match any "only"
regexps.

If fixes the previous logic that was requiring a path to match
all "only" patterns in order to not be silenced, meaning that
it was silenced as soon as it didn't match an "only" regexp
(even if it matched another "only" regexp).

I think with this logic, the `only` option works well, ~~no need for
`only_dirs` / `only_exts`, you can do it with regexps, .e.g.:~~

Edit: because of some adapters's and the current implementation, it's possible that a first check for silenced paths is done against directories only which would return `true` (i.e. "silenced") even if the `only` pattern defines an extension that would match a modified file _inside_ the false-positive-silenced directory.

**You can ignore the rest of this comment**

``` ruby
only: [%r{^foo/}, /\.rb$/]
```

will match (with `Dir.pwd` being `/Users/remy/project`:
- `/Users/remy/project/foo/bar.txt` (`foo/` folder)
- `/Users/remy/project/bar.rb` (`.rb` extension)
- `/Users/remy/project/bar/foo.rb` (`.rb` extension)

will not match:
- `/Users/remy/project/bar/foo.txt` (no `foo/` folder, no `.rb` extension)
- `/Users/remy/project/bar.txt` (no `foo/` folder, no `.rb` extension)
