### PR TITLE
add vendor/bundle to ignored directories

### DIFF
--- a/lib/listen/silencer.rb
+++ b/lib/listen/silencer.rb
@@ -3,7 +3,7 @@ module Listen
     include Celluloid
 
     # The default list of directories that get ignored.
-    DEFAULT_IGNORED_DIRECTORIES = %w[.bundle .git .hg .rbx .svn bundle log tmp vendor/ruby]
+    DEFAULT_IGNORED_DIRECTORIES = %w[.bundle .git .hg .rbx .svn bundle log tmp vendor/ruby vendor/bundle]
 
     # The default list of files that get ignored.
     DEFAULT_IGNORED_EXTENSIONS  = %w[.DS_Store .tmp]


### PR DESCRIPTION
[The guard docs](https://github.com/guard/guard#ignore) list vendor/bundle as being ignored, but only vendor/ruby was actually ignored.
