### PR TITLE
Fixes #181 and #185. Listener#listen? considers start/stopped state. Listeners can be restarted.

### DIFF
--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -6,7 +6,7 @@ require 'listen/silencer'
 
 module Listen
   class Listener
-    attr_accessor :options, :directories, :paused, :changes, :block, :thread
+    attr_accessor :options, :directories, :paused, :changes, :block, :thread, :stopping
     attr_accessor :registry, :supervisor
 
     RELATIVE_PATHS_WITH_MULTIPLE_DIRECTORIES_WARNING_MESSAGE = "The relative_paths option doesn't work when listening to multiple diretories."
@@ -39,6 +39,7 @@ module Listen
       _signals_trap
       _init_actors
       unpause
+      @stopping = false
       registry[:adapter].async.start
       @thread = Thread.new { _wait_for_changes }
     end
@@ -71,12 +72,12 @@ module Listen
       @paused == true
     end
 
-    # Returns true if Listener is not paused
+    # Returns true if Listener is neither paused nor stopped
     #
     # @return [Boolean]
     #
     def listen?
-      @paused == false
+      @paused == false && @stopping == false
     end
 
     # Adds ignore patterns to the existing one (See DEFAULT_IGNORED_DIRECTORIES and DEFAULT_IGNORED_EXTENSIONS in Listen::Silencer)

--- a/spec/lib/listen/listener_spec.rb
+++ b/spec/lib/listen/listener_spec.rb
@@ -168,17 +168,25 @@ describe Listen::Listener do
     end
   end
 
-  describe "#paused?" do
+  describe "#listen?" do
     it "returns true when not paused (false)" do
       listener.paused = false
+      listener.stopping = false
       expect(listener.listen?).to be_true
     end
     it "returns false when not paused (nil)" do
       listener.paused = nil
+      listener.stopping = false
       expect(listener.listen?).to be_false
     end
     it "returns false when paused" do
       listener.paused = true
+      listener.stopping = false
+      expect(listener.listen?).to be_false
+    end
+    it "returns false when stopped" do
+      listener.paused = false
+      listener.stopping = true
       expect(listener.listen?).to be_false
     end
   end


### PR DESCRIPTION
Before these changes, a `Listener#listen?` returned true even if a listener had been stopped.

Additionally, calling `stop` and then `start` on a listener did not re-start it.
