### PR TITLE
Fix typo in require statement in CLI

### DIFF
--- a/lib/listen/cli.rb
+++ b/lib/listen/cli.rb
@@ -1,5 +1,5 @@
 require 'thor'
-require 'Listen'
+require 'listen'
 
 module Listen
   class CLI < Thor


### PR DESCRIPTION
Because of this typo, listen can’t be used on CLI
