### PR TITLE
Move trapping of SIGINT to load time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ gem 'rb-kqueue', '>= 0.2' if RbConfig::CONFIG['target_os'] =~ /freebsd/i
 
 ### Issues
 
+Listen traps SIGINT signal to properly finalize listeners. If you plan
+on trapping this signal yourself - make sure to call `Listen.stop` in
+signal handler.
+
 Sometimes OS-specific adapters don't work. :'(
 Here are some things you could try to avoid forcing polling.
 

--- a/lib/listen.rb
+++ b/lib/listen.rb
@@ -57,7 +57,11 @@ module Listen
     def boot_celluloid
       Celluloid.boot unless Celluloid.running?
     end
-
   end
-
+  
+  unless defined?(JRUBY_VERSION)
+    if Signal.list.keys.include?('INT')
+      Signal.trap('INT') { Listen.stop }
+    end
+  end
 end

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -36,7 +36,6 @@ module Listen
     # for changes. The current thread is not blocked after starting.
     #
     def start
-      _signals_trap
       _init_actors
       unpause
       @stopping = false
@@ -133,13 +132,6 @@ module Listen
 
       adapter_class = Adapter.select(options)
       supervisor.add(adapter_class, as: :adapter, args: self)
-    end
-
-    def _signals_trap
-      return if defined?(JRUBY_VERSION)
-      if Signal.list.keys.include?('INT')
-        Signal.trap('INT') { stop }
-      end
     end
 
     def _wait_for_changes


### PR DESCRIPTION
Listener trapped SIGINT on every instantization.
This created problems with overriding SIGINT in client and created issue
where only one instance of Listener would be properly finalized leading
to a long shutdown + SEGFAULT in some cases.

This commit moves singal trapping to Listen module and sets up a trap
once at load time, calling Listen.stop which should properly finalize
all Listener instances.

Additionally information about signal trapping was added to README.md

Fixes #194
