### PR TITLE
Preventing finalization on dead actor

### DIFF
--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -145,7 +145,7 @@ module Listen
         sleep options[:wait_for_delay]
       end
 
-      supervisor.finalize
+      supervisor.finalize if supervisor.alive?
     rescue => ex
       Kernel.warn "[Listen warning]: Change block raised an exception: #{$!}"
       Kernel.warn "Backtrace:\n\t#{ex.backtrace.join("\n\t")}"

--- a/spec/lib/listen_spec.rb
+++ b/spec/lib/listen_spec.rb
@@ -26,6 +26,11 @@ describe Listen do
       Listen.stop
       expect(Listen.stopping).to be_true
     end
+
+    it "stops all listeners via SIGINT" do
+      Process.kill("INT", Process.pid)
+      expect(Listen.stopping).to be_true
+    end
   end
 
   describe '.on' do


### PR DESCRIPTION
When using Calluloid.shutdown there's race condition between listeners
and celluloid which in some cases leads to Listener calling #finalize on
dead actor. Added a guard that checks if actor is alive when we're
exiting from #_wait_for_changes and calls finalizer only if it's alive.

PS. I couldn't for a life figure out how to make this test pass. I hate
mocking libraries with all my heart. Feel free to fix this.

Fixes #197
