### PR TITLE
Feature: add silence_record_build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ polling_fallback_message: 'custom message'      # Set a custom polling fallback 
 
 debug: true                                     # Enable Celluloid logger
                                                 # default: false
+
+silence_record_build: false                     # Report records that exist as at initialisation as Add events 
+                                                # default: true
 ```
 
 ## Listen adapters

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -58,7 +58,7 @@ module Listen
     # Unpauses listening callback
     #
     def unpause
-      registry[:record].build
+      registry[:record].build(options[:silence_record_build])
       @paused = false
     end
 
@@ -113,7 +113,8 @@ module Listen
         latency: nil,
         wait_for_delay: 0.1,
         force_polling: false,
-        polling_fallback_message: nil }.merge(options)
+        polling_fallback_message: nil,
+        silence_record_build: true }.merge(options)
     end
 
     def _init_debug

--- a/lib/listen/record.rb
+++ b/lib/listen/record.rb
@@ -25,10 +25,10 @@ module Listen
       @paths[path.to_s]
     end
 
-    def build
+    def build(silence=true)
       @paths = _init_paths
       listener.directories.each do |path|
-        listener.registry[:change_pool].change(path, type: 'Dir', recursive: true, silence: true)
+        listener.registry[:change_pool].change(path, type: 'Dir', recursive: true, silence: silence)
       end
     end
 

--- a/spec/acceptance/listen_spec.rb
+++ b/spec/acceptance/listen_spec.rb
@@ -185,6 +185,17 @@ describe "Listen" do
           end
         end
 
+        context "with silence_record_build option" do
+          around { |example| touch 'file.rb'; example.run }
+          let(:options) { { force_polling: polling, latency: 0.1, silence_record_build: false} }
+
+          it "treats existing file as an add" do
+            expect(listen { 
+              touch 'file.txt' 
+              }).to eq({ modified: [], added: ['file.rb', 'file.txt'], removed: [] })
+          end
+        end
+
         context "with only option" do
           let(:options) { { force_polling: polling, latency: 0.1, only: /\.rb$/ } }
 

--- a/spec/lib/listen/listener_spec.rb
+++ b/spec/lib/listen/listener_spec.rb
@@ -44,17 +44,19 @@ describe Listen::Listener do
         latency: nil,
         wait_for_delay: 0.1,
         force_polling: false,
-        polling_fallback_message: nil })
+        polling_fallback_message: nil,
+        silence_record_build: true })
     end
 
     it "sets new options on initialize" do
-      listener = Listen::Listener.new('lib', latency: 1.234, wait_for_delay: 0.85)
+      listener = Listen::Listener.new('lib', latency: 1.234, wait_for_delay: 0.85, silence_record_build: false)
       expect(listener.options).to eq({
         debug: false,
         latency: 1.234,
         wait_for_delay: 0.85,
         force_polling: false,
-        polling_fallback_message: nil })
+        polling_fallback_message: nil,
+        silence_record_build: false })
     end
   end
 

--- a/spec/lib/listen/record_spec.rb
+++ b/spec/lib/listen/record_spec.rb
@@ -89,5 +89,10 @@ describe Listen::Record do
       expect(change_pool).to receive(:change).with('dir_path', type: 'Dir', recursive: true, silence: true)
       record.build
     end
+
+    it "calls change with silence false"  do
+      expect(change_pool).to receive(:change).with('dir_path', type: 'Dir', recursive: true, silence: false)
+      record.build(false)
+    end
   end
 end


### PR DESCRIPTION
effectively allows listen to report existing files as an add event so
that the same treatment can be applied to existing and newly added
files.

Note that while it seems to work well when I fold it into some test code and my non-acceptance tests pass ok, I am unable to get my acceptance test to work... (https://github.com/hackify/listen/blob/master/spec/acceptance/listen_spec.rb#L188)

I created this because I am building a ruby port of my Node.js module for hackify.org (https://github.com/hackify/hackify).  The node module I use for listening to the file system (https://github.com/paulmillr/chokidar) supports this feature.

The feature is useful for this application because I need to do an initial listing of files in my 'watched' folder as well as report differences.  Without this feature, I would need to have a separate function to recursively browse the folders and apply the ignore regex as well.  Pretty messy I thought. 
