### PR TITLE
Added more default ignores that speed up guard significantly on rails

### DIFF
--- a/lib/listen/silencer.rb
+++ b/lib/listen/silencer.rb
@@ -3,7 +3,7 @@ module Listen
     include Celluloid
 
     # The default list of directories that get ignored.
-    DEFAULT_IGNORED_DIRECTORIES = %w[.bundle .git .hg .rbx .svn bundle log tmp vendor/ruby vendor/bundle]
+    DEFAULT_IGNORED_DIRECTORIES = %w[.bundle .git .hg .rbx .svn bundle log tmp vendor/ruby vendor/bundle bin config db lib public]
 
     # The default list of files that get ignored.
     DEFAULT_IGNORED_EXTENSIONS  = %w[.DS_Store .tmp]


### PR DESCRIPTION
Perhaps this is a better place than here: https://github.com/guard/guard-rspec/pull/260 to add more ignores? These sped up guard significantly on my system. Took me from 100% idling on a large Rails project down to .1%. 
