### PR TITLE
fix frozen string warning in Ruby 2.1.1

### DIFF
--- a/spec/support/acceptance_helper.rb
+++ b/spec/support/acceptance_helper.rb
@@ -24,8 +24,9 @@ end
 
 def relative_path(changes)
   changes.map do |change|
-    [paths].flatten.each { |path| change.gsub!(%r{#{path.to_s}/}, '') }
-    change
+    unfrozen_copy = change.dup
+    [paths].flatten.each { |path| unfrozen_copy.gsub!(%r{#{path.to_s}/}, '') }
+    unfrozen_copy
   end
 end
 


### PR DESCRIPTION
Occurs as a captured "Listen warning" while working on broken specs (but not during full spec run).
