### PR TITLE
show inotify limit error *before* calling abort

### DIFF
--- a/lib/listen/adapter/linux.rb
+++ b/lib/listen/adapter/linux.rb
@@ -14,7 +14,7 @@ module Listen
       # The message to show when the limit of inotify watchers is not enough
       #
       INOTIFY_LIMIT_MESSAGE = <<-EOS.gsub(/^\s*/, '')
-        Listen error: unable to monitor directories for changes.
+        FATAL: Listen error: unable to monitor directories for changes.
 
         Please head to https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers
         for information on how to solve this issue.
@@ -33,6 +33,8 @@ module Listen
         worker = _init_worker
         Thread.new { worker.run }
       rescue Errno::ENOSPC
+        STDERR.puts INOTIFY_LIMIT_MESSAGE
+        STDERR.flush
         abort(INOTIFY_LIMIT_MESSAGE)
       end
 

--- a/spec/lib/listen/adapter/linux_spec.rb
+++ b/spec/lib/listen/adapter/linux_spec.rb
@@ -17,6 +17,26 @@ describe Listen::Adapter::Linux do
         expect(defined?(INotify)).to be_true
       end
     end
+
+    # workaround: Celluloid ignores SystemExit exception messages
+    describe "inotify limit message" do
+      let(:adapter) { described_class.new(listener) }
+      let(:expected_message) { described_class.const_get('INOTIFY_LIMIT_MESSAGE') }
+
+      before do
+        allow_any_instance_of(INotify::Notifier).to receive(:watch).and_raise(Errno::ENOSPC)
+        allow(listener).to receive(:directories) { [ 'foo/dir' ] }
+      end
+
+      it "should be show before calling abort" do
+        expect(STDERR).to receive(:puts).with(expected_message)
+
+        # Expect RuntimeError here, for the sake of unit testing (actual
+        # handling depends on Celluloid supervisor setup, which is beyond the
+        # scope of adapter tests)
+        expect{adapter.start}.to raise_error RuntimeError, expected_message
+      end
+    end
   end
 
   if darwin?


### PR DESCRIPTION
Celluloid catches abort(SystemExit) and shuts down the supervisor group
without displaying the abort message.
