### PR TITLE
Use proper attempts variable on ECONNREFUSED

### DIFF
--- a/lib/listen/adapter/tcp.rb
+++ b/lib/listen/adapter/tcp.rb
@@ -20,7 +20,7 @@ module Listen
 
       # Initializes and starts a Celluloid::IO-powered TCP-recipient
       def start
-        attempts = 3
+        attempts ||= 3
         @socket = TCPSocket.new(options.host, options.port)
         @buffer = ''
         async.run
@@ -30,7 +30,7 @@ module Listen
         sleep 1
         attempts -= 1
         _log :warn, "TCP.start: #{$!.inspect}"
-        retry if retries > 0
+        retry if attempts > 0
         _log :error, "TCP.start: #{$!.inspect}:#{$@.join("\n")}"
         raise
       rescue


### PR DESCRIPTION
Previous to this commit, the Listen::Adapter#start method incorrectly
used the 'retries' variable instead of the correct 'attempts' variable to
count the number of attempts that have occurred.

Further, the attempts variable was reset to the value of 3 on every
retry causing indefinite retries.

This commit renames the 'retries' variable to 'attempts' and also only
sets the 'attempts' variable to a value of 3 if it does not already have
a value.
