### PR TITLE
Avoid using Celluloid.logger in case it is nil

### DIFF
--- a/lib/listen/adapter.rb
+++ b/lib/listen/adapter.rb
@@ -38,7 +38,7 @@ module Listen
     end
 
     def self._log(type, message)
-      Celluloid.logger.send(type, message)
+      Celluloid::Logger.send(type, message)
     end
   end
 end

--- a/lib/listen/adapter/base.rb
+++ b/lib/listen/adapter/base.rb
@@ -84,7 +84,7 @@ module Listen
       end
 
       def self._log(*args)
-        Celluloid.logger.send(*args)
+        Celluloid::Logger.send(*args)
       end
     end
   end

--- a/lib/listen/change.rb
+++ b/lib/listen/change.rb
@@ -52,7 +52,7 @@ module Listen
     private
 
     def _log(type, message)
-      Celluloid.logger.send(type, message)
+      Celluloid::Logger.send(type, message)
     end
   end
 end

--- a/lib/listen/directory.rb
+++ b/lib/listen/directory.rb
@@ -14,11 +14,15 @@ module Listen
       current = Set.new(path.children)
 
       if options[:silence]
-        _log(:debug) { "Recording: #{rel_path}: #{options.inspect}"\
-          " [#{previous.inspect}] -> (#{current.inspect})" }
+        _log(:debug) do
+          "Recording: #{rel_path}: #{options.inspect}"\
+            " [#{previous.inspect}] -> (#{current.inspect})"
+        end
       else
-        _log(:debug) { "Scanning: #{rel_path}: #{options.inspect}"\
-          " [#{previous.inspect}] -> (#{current.inspect})" }
+        _log(:debug) do
+          "Scanning: #{rel_path}: #{options.inspect}"\
+          " [#{previous.inspect}] -> (#{current.inspect})"
+        end
       end
 
       current.each do |full_path|
@@ -69,6 +73,7 @@ module Listen
     end
 
     def self._log(type, &block)
+      return unless Celluloid.logger
       Celluloid.logger.send(type) do
         block.call
       end

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -37,8 +37,10 @@ module Listen
       @options = _init_options(args.last.is_a?(Hash) ? args.pop : {})
 
       # Setup logging first
-      Celluloid.logger.level = _debug_level
-      _log :info, "Celluloid loglevel set to: #{Celluloid.logger.level}"
+      if Celluloid.logger
+        Celluloid.logger.level = _debug_level
+        _log :info, "Celluloid loglevel set to: #{Celluloid.logger.level}"
+      end
 
       @silencer = Silencer.new
       _reconfigure_silencer({})
@@ -252,7 +254,7 @@ module Listen
     end
 
     def _log(type, message)
-      Celluloid.logger.send(type, message)
+      Celluloid::Logger.send(type, message)
     end
 
     def _adapter_class

--- a/lib/listen/record.rb
+++ b/lib/listen/record.rb
@@ -65,9 +65,9 @@ module Listen
         _fast_build(directory.to_s)
       end
 
-      Celluloid.logger.info "Record.build took #{Time.now.to_f - start} seconds"
+      Celluloid::Logger.info "Record.build(): #{Time.now.to_f - start} seconds"
     rescue
-      Celluloid.logger.warn "build crashed: #{$!.inspect}"
+      Celluloid::Logger.warn "build crashed: #{$!.inspect}"
       raise
     end
 

--- a/lib/listen/tcp/broadcaster.rb
+++ b/lib/listen/tcp/broadcaster.rb
@@ -61,7 +61,7 @@ module Listen
       private
 
       def _log(type, message)
-        Celluloid.logger.send(type, message)
+        Celluloid::Logger.send(type, message)
       end
 
       def _unicast(socket, payload)


### PR DESCRIPTION
Fixes #248 

(Celluloid::Logger methods check Celluloid.logger presence)
