### PR TITLE
skip already watched symlinked dirs

### DIFF
--- a/lib/listen/record.rb
+++ b/lib/listen/record.rb
@@ -115,12 +115,12 @@ module Listen
 
     def _fast_build_dir(remaining, symlink_detector)
       entry = remaining.pop
-      entry.children.each { |child| remaining << child }
       symlink_detector.verify_unwatched!(entry)
+      entry.children.each { |child| remaining << child }
       add_dir(entry.root, entry.record_dir_key)
     rescue Errno::ENOTDIR
       _fast_try_file(entry)
-    rescue SystemCallError
+    rescue SystemCallError, SymlinkDetector::Error
       _fast_unset_path(entry.root, entry.relative, entry.name)
     end
 

--- a/lib/listen/record/symlink_detector.rb
+++ b/lib/listen/record/symlink_detector.rb
@@ -4,42 +4,20 @@ module Listen
   # @private api
   class Record
     class SymlinkDetector
+      WIKI = 'https://github.com/guard/listen/wiki/Duplicate-directory-errors'
+
       SYMLINK_LOOP_ERROR = <<-EOS
-        ** ERROR: Listen detected a duplicate directory being watched! **
+        ** ERROR: directory is already being watched! **
 
-        (This may be due to multiple symlinks pointing to already watched dirs).
+        Directory: %s
 
-        Duplicate: %s
+        is already begin watched through: %s
 
-        which already is added as: %s
-
-        Listen is refusing to continue, because it may cause an infinite loop,
-        a crash or confusing results.
-
-        Suggestions:
-
-          1) (best option) watch only directories you care about (e.g.
-          either symlinked folders or folders with the real directories,
-          but not both).
-
-          IMPORTANT: The `:ignore` options DO NOT HELP here
-          (see: https://github.com/guard/listen/issues/274)
-
-          NOTE: If you are using Listen through some other application
-          (like Guard, Compass, Jekyll, Vagrant), check the documentation on
-          selecting watched directories (e.g. Guard has a `-w` option, Compass
-          allows you to specify multiple input/output directories, etc.)
-
-          2) reorganize your project so that watched directories do not
-          contain symlinked directories
-
-          3) submit patches so that Listen can reliably and quickly (!)
-          detect symlinks to already watched read directories, skip
-          them, and then reasonably choose which symlinked paths to
-          report as changed (if any)
-
-        Issue: https://github.com/guard/listen/issues/259
+        MORE INFO: #{WIKI}
       EOS
+
+      class Error < RuntimeError
+      end
 
       def initialize
         @real_dirs = Set.new
@@ -54,9 +32,7 @@ module Listen
 
       def _fail(symlinked, real_path)
         STDERR.puts format(SYMLINK_LOOP_ERROR, symlinked, real_path)
-
-        # Note Celluloid eats up abort message anyway
-        fail 'Failed due to looped symlinks'
+        fail Error, 'Failed due to looped symlinks'
       end
     end
   end

--- a/spec/lib/listen/record_spec.rb
+++ b/spec/lib/listen/record_spec.rb
@@ -232,6 +232,10 @@ describe Listen::Record do
 
         allow(::File).to receive(:realpath).with('/dir1').and_return('/dir1')
         allow(::File).to receive(:realpath).with('/dir2').and_return('/dir2')
+        allow(::File).to receive(:realpath).with('/dir1/foo').
+          and_return('/dir1/foo')
+        allow(::File).to receive(:realpath).with('/dir1/bar').
+          and_return('/dir1/bar')
       end
 
       it 'builds record' do
@@ -256,6 +260,8 @@ describe Listen::Record do
         allow(::File).to receive(:realpath).with('/dir2').and_return('/dir2')
         allow(::File).to receive(:realpath).with('/dir1/foo').
           and_return('/dir1/foo')
+        allow(::File).to receive(:realpath).with('/dir1/foo/bar').
+          and_return('/dir1/foo/bar')
       end
 
       it 'builds record'  do
@@ -295,15 +301,19 @@ describe Listen::Record do
       before do
         allow(::Dir).to receive(:entries).with('/dir1') { %w(foo) }
         allow(::Dir).to receive(:entries).with('/dir1/foo') { %w(foo) }
+        allow(::Dir).to receive(:entries).with('/dir2') { [] }
         allow(::File).to receive(:realpath).with('/dir1').and_return('/bar')
         allow(::File).to receive(:realpath).with('/dir1/foo').and_return('/bar')
+        allow(::File).to receive(:realpath).with('/dir2').and_return('/dir2')
       end
 
       it 'shows message and aborts with error' do
-        expect(STDERR).to receive(:puts).with(/detected a duplicate directory/)
+        expect(STDERR).to receive(:puts).
+          with(/directory is already being watched/)
 
-        expect { record.build }.to raise_error(RuntimeError,
-                                               /Failed due to looped symlinks/)
+        record.build
+        # expect { record.build }.
+        # to raise_error(RuntimeError, /Failed due to looped symlinks/)
       end
     end
   end


### PR DESCRIPTION
- when a duplicate directory is detected, listen shows an error (to STDERR, so it hopefully skips logging) and aborts scanning the directory
- reduced message to instead link to wiki entry
