### PR TITLE
avoid symlink check on files [closes #282]

### DIFF
--- a/lib/listen/record.rb
+++ b/lib/listen/record.rb
@@ -115,8 +115,9 @@ module Listen
 
     def _fast_build_dir(remaining, symlink_detector)
       entry = remaining.pop
+      children = entry.children # NOTE: children() implicitly tests if dir
       symlink_detector.verify_unwatched!(entry)
-      entry.children.each { |child| remaining << child }
+      children.each { |child| remaining << child }
       add_dir(entry.root, entry.record_dir_key)
     rescue Errno::ENOTDIR
       _fast_try_file(entry)


### PR DESCRIPTION
- regression introduced in 2.8.2
- refactored specs to make them more readable (sadly, FakeFS is not an option because of integrated tests)
