### PR TITLE
Fixed anchor link for polling fallback message.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ debug: true                                     # Enable Celluloid logger
                                                 # default: false
 
 polling_fallback_message: 'custom message'      # Set a custom polling fallback message (or disable it with false)
-                                                # default: "Listen will be polling for changes. Learn more at https://github.com/guard/listen#polling-fallback."
+                                                # default: "Listen will be polling for changes. Learn more at https://github.com/guard/listen#listen-adapters."
 ```
 
 Also, setting the environment variable `LISTEN_GEM_DEBUGGING=1` does the same as `debug: true` above.

--- a/lib/listen/adapter.rb
+++ b/lib/listen/adapter.rb
@@ -9,7 +9,7 @@ module Listen
   module Adapter
     OPTIMIZED_ADAPTERS = [Darwin, Linux, BSD, Windows]
     POLLING_FALLBACK_MESSAGE = 'Listen will be polling for changes.'\
-      'Learn more at https://github.com/guard/listen#polling-fallback.'
+      'Learn more at https://github.com/guard/listen#listen-adapters.'
 
     def self.select(options = {})
       _log :debug, 'Adapter: considering TCP ...'


### PR DESCRIPTION
For more info, see: 

After editing the two files mentioned in guard/listen#284, I ran `rake spec` which returned `340 examples, 0 failures`.

Note that I edited the `README.md` directly. I'm not familiar with [YARD](http://yardoc.org/guides/index.html), so please let me know if I missed something here.
