### PR TITLE
avoid evaluating code in debug logs

### DIFF
--- a/lib/listen/adapter/base.rb
+++ b/lib/listen/adapter/base.rb
@@ -79,16 +79,20 @@ module Listen
         @mq.send(:_queue_raw_change, type, dir, rel_path, options)
       end
 
-      def _log(*args)
-        self.class.send(:_log, *args)
+      def _log(*args, &block)
+        self.class.send(:_log, *args, &block)
       end
 
       def _log_exception(msg)
         _log :error, format(msg, $ERROR_INFO, $ERROR_POSITION * "\n")
       end
 
-      def self._log(*args)
-        Celluloid::Logger.send(*args)
+      def self._log(*args, &block)
+        if block
+          Celluloid::Logger.send(*args, block.call)
+        else
+          Celluloid::Logger.send(*args)
+        end
       end
     end
   end

--- a/lib/listen/adapter/tcp.rb
+++ b/lib/listen/adapter/tcp.rb
@@ -75,7 +75,8 @@ module Listen
       # Handles incoming message by notifying of path changes
       def handle_message(message)
         type, change, dir, path, _ = message.object
-        _log :debug, "TCP message: #{[type, change, dir, path].inspect}"
+        _log(:debug) { "TCP message: #{[type, change, dir, path].inspect}" }
+
         _queue_change(type.to_sym, Pathname(dir), path, change: change.to_sym)
       end
 

--- a/lib/listen/internals/logging.rb
+++ b/lib/listen/internals/logging.rb
@@ -3,20 +3,24 @@ require 'celluloid/logger'
 module Listen
   module Internals
     module Logging
-      def _info(*args)
-        _log(:info, *args)
+      def _info(*args, &block)
+        _log(:info, *args, &block)
       end
 
-      def _warn(*args)
-        _log(:warn, *args)
+      def _warn(*args, &block)
+        _log(:warn, *args, &block)
       end
 
-      def _debug(*args)
-        _log(:debug, *args)
+      def _debug(*args, &block)
+        _log(:debug, *args, &block)
       end
 
-      def _log(*args)
-        Celluloid::Logger.send(*args)
+      def _log(*args, &block)
+        if block
+          Celluloid::Logger.send(*args, block.call)
+        else
+          Celluloid::Logger.send(*args)
+        end
       end
 
       def _format_error(fmt)

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -332,7 +332,7 @@ module Listen
     end
 
     def _queue_raw_change(type, dir, rel_path, options)
-      _debug "raw queue: #{[type, dir, rel_path, options].inspect}"
+      _debug { "raw queue: #{[type, dir, rel_path, options].inspect}" }
 
       unless (worker = async(:change_pool))
         _warn 'Failed to allocate worker from change pool'


### PR DESCRIPTION
- to avoid calling "inspect" on files with multiple encodings
- possibly slight performance gain