### PR TITLE
Reintroduce *BSD support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ when /mswin|mingw|cygwin/i
   Kernel.warn 'NOTE: Celluloid may not work properly on your platform'
 when /bsd|dragonfly/i
   gem 'rb-kqueue', '>= 0.2'
-  Kernel.warn 'NOTE: You are using BSD. You are on your own!'
 end
 
 group :test do

--- a/README.md
+++ b/README.md
@@ -207,7 +207,6 @@ Please add the following to your Gemfile:
 
 ```ruby
 require 'rbconfig'
-gem 'rb-kqueue', '>= 0.2'
 if RbConfig::CONFIG['target_os'] =~ /bsd|dragonfly/i
   gem 'rb-kqueue', '>= 0.2'
 end

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Make sure you know these few basic tricks: https://github.com/guard/listen/wiki/
 
 ## Features
 
-* OS-optimized adapters on MRI for Mac OS X 10.6+, Linux, ~~\*BSD~~ and Windows, [more info](#listen-adapters) below.
+* OS-optimized adapters on MRI for Mac OS X 10.6+, Linux, \*BSD and Windows, [more info](#listen-adapters) below.
 * Detects file modification, addition and removal.
 * You can watch multiple directories.
 * Regexp-patterns for ignoring paths for more accuracy and speed
@@ -28,7 +28,6 @@ Please note that:
 - Some filesystems won't work without polling (VM/Vagrant Shared folders, NFS, Samba, sshfs, etc.)
 - Specs suite on JRuby and Rubinius aren't reliable on Travis CI, but should work.
 - Windows and \*BSD adapter aren't continuously and automaticaly tested.
-- \*BSD is broken and not supported any more, see: [#220](https://github.com/guard/listen/issues/220)
 
 ## Pending features / issues
 
@@ -178,7 +177,7 @@ Also, setting the environment variable `LISTEN_GEM_DEBUGGING=1` does the same as
 
 The Listen gem has a set of adapters to notify it when there are changes.
 
-There are 4 OS-specific adapters to support Darwin, Linux, ~~\*BSD~~ and Windows.
+There are 4 OS-specific adapters to support Darwin, Linux, \*BSD and Windows.
 These adapters are fast as they use some system-calls to implement the notifying function.
 
 There is also a polling adapter - although it's much slower than other adapters,
@@ -202,8 +201,6 @@ gem 'wdm', '>= 0.1.0' if Gem.win_platform?
 
 ### On \*BSD
 
-**NOTE: \*BSD currently is BROKEN with no plans to fix it or support it (see: [#220](https://github.com/guard/listen/issues/220))**
-
 If your are on \*BSD you can try to use the [`rb-kqueue`](https://github.com/mat813/rb-kqueue) instead of polling.
 
 Please add the following to your Gemfile:
@@ -213,11 +210,6 @@ require 'rbconfig'
 gem 'rb-kqueue', '>= 0.2'
 if RbConfig::CONFIG['target_os'] =~ /bsd|dragonfly/i
   gem 'rb-kqueue', '>= 0.2'
-
-  # Base versions have known conflicts/bugs
-  # Even master branches may not work...
-  gem 'ffi', github: 'carpetsmoker/ffi', ref: 'ac63e07f7'
-  gem 'celluloid', github: 'celluloid/celluloid', ref: '7fdef04'
 end
 
 ```

--- a/lib/listen/adapter/bsd.rb
+++ b/lib/listen/adapter/bsd.rb
@@ -58,6 +58,7 @@ module Listen
 
       def _configure(directory, &_callback)
         @worker ||= KQueue::Queue.new
+        @callback = _callback
         # use Record to make a snapshot of dir, so we
         # can detect new files
         _find(directory.to_s) { |path| _watch_file(path, @worker) }
@@ -109,7 +110,7 @@ module Listen
       end
 
       def _watch_file(path, queue)
-        queue.watch_file(path, *options.events, &_worker_callback)
+        queue.watch_file(path, *options.events, &@callback)
       end
 
       # Quick rubocop workaround

--- a/lib/listen/adapter/bsd.rb
+++ b/lib/listen/adapter/bsd.rb
@@ -23,11 +23,6 @@ module Listen
           require 'rbconfig'
           if RbConfig::CONFIG['target_os'] =~ #{OS_REGEXP}
             gem 'rb-kqueue', '>= 0.2'
-
-            # Base versions have known conflicts/bugs
-            # Even master branches may not work...
-            gem 'ffi', github: 'carpetsmoker/ffi', ref: 'ac63e07f7'
-            gem 'celluloid', github: 'celluloid/celluloid', ref: '7fdef04'
           end
       EOS
 

--- a/lib/listen/adapter/bsd.rb
+++ b/lib/listen/adapter/bsd.rb
@@ -31,21 +31,8 @@ module Listen
           end
       EOS
 
-      BSD_EXPERIMENTAL = <<-EOS.gsub(/^ {6}/, '')
-        NOTE *BSD SUPPORT IS EXPERIMENTAL!
-
-        In fact, it likely WONT WORK!!!!
-
-        (see: https://github.com/guard/listen/issues/220)
-
-        If you're brave enough, feel free to suggest pull requests and
-        experiment on your own. For help, browse existing issues marked 'bsd'
-        for clues, tips and workaround.
-      EOS
-
       def self.usable?
         return false unless super
-        Kernel.warn BSD_EXPERIMENTAL
         require 'rb-kqueue'
         require 'find'
         true

--- a/lib/listen/adapter/bsd.rb
+++ b/lib/listen/adapter/bsd.rb
@@ -56,7 +56,7 @@ module Listen
           # Force dir content tracking to kick in, or we won't have
           # names of added files
           _queue_change(:dir, dir, '.', recursive: true)
-        else
+        elsif full_path.exist?
           path = full_path.relative_path_from(dir)
           _queue_change(:file, dir, path.to_s, change: _change(event.flags))
         end

--- a/lib/listen/adapter/bsd.rb
+++ b/lib/listen/adapter/bsd.rb
@@ -76,7 +76,7 @@ module Listen
           _queue_change(:dir, dir, '.', recursive: true)
         else
           path = full_path.relative_path_from(dir)
-          _queue_change(:file, dir, path, change: _change(event.flags))
+          _queue_change(:file, dir, path.to_s, change: _change(event.flags))
         end
 
         # If it is a directory, and it has a write flag, it means a

--- a/lib/listen/adapter/bsd.rb
+++ b/lib/listen/adapter/bsd.rb
@@ -83,7 +83,7 @@ module Listen
         # file has been added so find out which and deal with it.
         # No need to check for removed files, kqueue will forget them
         # when the vfs does.
-        _watch_for_new_file(event) if path.directory?
+        _watch_for_new_file(event) if full_path.directory?
       end
 
       def _change(event_flags)

--- a/lib/listen/adapter/bsd.rb
+++ b/lib/listen/adapter/bsd.rb
@@ -113,8 +113,8 @@ module Listen
       end
 
       # Quick rubocop workaround
-      def _find(*paths)
-        Find.send(:find, *paths)
+      def _find(*paths, &block)
+        Find.send(:find, *paths, &block)
       end
     end
   end

--- a/lib/listen/adapter/bsd.rb
+++ b/lib/listen/adapter/bsd.rb
@@ -21,7 +21,7 @@ module Listen
       BUNDLER_DECLARE_GEM = <<-EOS.gsub(/^ {6}/, '')
         Please add the following to your Gemfile to avoid polling for changes:
           require 'rbconfig'
-          if RbConfig::CONFIG['target_os'] =~ #{OS_REGEXP}
+          if RbConfig::CONFIG['target_os'] =~ /#{OS_REGEXP}/
             gem 'rb-kqueue', '>= 0.2'
           end
       EOS


### PR DESCRIPTION
Hello !

#220 suggests that \*BSD support is broken, here is a fix!

This was tested on FreeBSD 10.1-STABLE, but does not touch to *low-level* things so if `rb-kqueue` works as expected on other BSD variants, it's expected to be fine there too :smile: .

~~~
Finished in 6 minutes 22 seconds (files took 2.57 seconds to load)
349 examples, 0 failures
~~~

I removed startup warnings because it cluttered a lot the output of `rspec`, but I did not changed the `README.md` file not removed the warning from the Gemfile as I don't know what you would prefer:

* Reintegrate \*BSD as supported platforms;
* Keep some *here be dragons* warning;
* Drop the BSD stuff (I don't hope so!).

Just tell me what you would like and I'll add a few commits to the pull request accordingly.

Thanks!