### PR TITLE
Update README (info on rb-kqueue adapter) [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ gem 'wdm', '>= 0.1.0' if Gem.win_platform?
 
 ### On \*BSD
 
-If your are on \*BSD you can try to use the [`rb-kqueue`](https://github.com/mat813/rb-kqueue) instead of polling.
+If your are on \*BSD you can try to use the [`rb-kqueue`](https://github.com/mat813/rb-kqueue) adapter instead of polling.
 
 Please add the following to your Gemfile:
 


### PR DESCRIPTION
At other places in the README, adapters are mentioned explicitly with
"adapter", except in this line, I think the text is more clear with
this change.
