### PR TITLE
Ignore kqueue errors on removed entries

### DIFF
--- a/lib/listen/adapter/bsd.rb
+++ b/lib/listen/adapter/bsd.rb
@@ -93,6 +93,8 @@ module Listen
 
       def _watch_file(path, queue)
         queue.watch_file(path, *options.events, &@callback)
+      rescue Errno::ENOENT => e
+        _log :warn, "kqueue: watch file failed: #{e.message}"
       end
 
       # Quick rubocop workaround


### PR DESCRIPTION
  When the BSD adapter decides it will watch a new file, it may happen
that the file was already removed when the call to watch this file
actually happens, raising Errno::ENOENT exception.

  As a workaround, we rescue this specific error and log a warning, in
case of a more serious issue than just an ephemeral file.

  Exception example:

    E, [2015-03-14T20:07:52.726600 #2299] ERROR -- : run() in thread failed: No such file or directory - Failed to open file /.../src/my/listen-kqueue/tmp/toto: File doesn't exist.:/.../.gem/ruby/22/gems/rb-kqueue-0.2.3/lib/rb-kqueue/watcher/file.rb:19:in `initialize'
    /.../.gem/ruby/22/gems/rb-kqueue-0.2.3/lib/rb-kqueue/queue.rb:227:in `new'
    /.../.gem/ruby/22/gems/rb-kqueue-0.2.3/lib/rb-kqueue/queue.rb:227:in `watch_file'
    /.../src/sys/listen/lib/listen/adapter/bsd.rb:96:in `_watch_file'
    /.../src/sys/listen/lib/listen/adapter/bsd.rb:89:in `block in _watch_for_new_file'
    /usr/local/lib/ruby/2.2/find.rb:48:in `block (2 levels) in find'
    /usr/local/lib/ruby/2.2/find.rb:47:in `catch'
    /usr/local/lib/ruby/2.2/find.rb:47:in `block in find'
    /usr/local/lib/ruby/2.2/find.rb:42:in `each'
    /usr/local/lib/ruby/2.2/find.rb:42:in `find'
    /.../src/sys/listen/lib/listen/adapter/bsd.rb:103:in `_find'
    /.../src/sys/listen/lib/listen/adapter/bsd.rb:87:in `_watch_for_new_file'
    /.../src/sys/listen/lib/listen/adapter/bsd.rb:68:in `_process_event'
    /.../src/sys/listen/lib/listen/adapter/base.rb:47:in `block (2 levels) in configure'
    /.../.gem/ruby/22/gems/rb-kqueue-0.2.3/lib/rb-kqueue/watcher.rb:90:in `call'
    /.../.gem/ruby/22/gems/rb-kqueue-0.2.3/lib/rb-kqueue/watcher.rb:90:in `callback!'
    /.../.gem/ruby/22/gems/rb-kqueue-0.2.3/lib/rb-kqueue/event.rb:80:in `callback!'
    /.../.gem/ruby/22/gems/rb-kqueue-0.2.3/lib/rb-kqueue/queue.rb:337:in `block in process'
    /.../.gem/ruby/22/gems/rb-kqueue-0.2.3/lib/rb-kqueue/queue.rb:337:in `each'
    /.../.gem/ruby/22/gems/rb-kqueue-0.2.3/lib/rb-kqueue/queue.rb:337:in `process'
    /.../.gem/ruby/22/gems/rb-kqueue-0.2.3/lib/rb-kqueue/queue.rb:316:in `run'
    /.../src/sys/listen/lib/listen/adapter/bsd.rb:50:in `_run'
    /.../src/sys/listen/lib/listen/adapter/base.rb:58:in `block in start'
    /.../src/sys/listen/lib/listen/internals/thread_pool.rb:7:in `call'
    /.../src/sys/listen/lib/listen/internals/thread_pool.rb:7:in `block in add'

  Warning example, with this change:

    W, [2015-03-14T20:21:16.209281 #5997]  WARN -- : kqueue: watch file failed: No such file or directory - Failed to open file /.../src/my/listen-kqueue/tmp/toto: File doesn't exist.
    I, [2015-03-14T20:21:16.313068 #5997]  INFO -- : listen: raw changes: [[:removed, "/.../src/my/listen-kqueue/tmp/toto"]]
    I, [2015-03-14T20:21:16.313146 #5997]  INFO -- : listen: final changes: {:modified=>[], :added=>[], :removed=>["/.../src/my/listen-kqueue/tmp/toto"]}
    […]
