### PR TITLE
listen -d can take multiple directories

### DIFF
--- a/lib/listen/cli.rb
+++ b/lib/listen/cli.rb
@@ -21,7 +21,7 @@ module Listen
                  banner:  'The address to forward filesystem events'
 
     class_option :directory,
-                 type:    :string,
+                 type:    :array,
                  default: '.',
                  aliases: '-d',
                  banner:  'The directory to listen to'

--- a/spec/lib/listen/cli_spec.rb
+++ b/spec/lib/listen/cli_spec.rb
@@ -8,6 +8,41 @@ RSpec.describe Listen::CLI do
     allow(forwarder).to receive(:start)
   end
 
+  describe 'directories option' do
+    context 'not specified' do
+      let(:options) { %w[] }
+      it 'is set to local directory' do
+        expect(Listen::Forwarder).to receive(:new) do |options|
+          expect(options[:directory]).to eq('.')
+          forwarder
+        end
+        described_class.start(options)
+      end
+    end
+
+    context 'with a single directory' do
+      let(:options) { %w[-d app] }
+      it 'is set to app' do
+        expect(Listen::Forwarder).to receive(:new) do |options|
+          expect(options[:directory]).to eq(['app'])
+          forwarder
+        end
+        described_class.start(options)
+      end
+    end
+
+    context 'with a multiple directories' do
+      let(:options) { %w[-d app spec] }
+      it 'is set to an array of the directories' do
+        expect(Listen::Forwarder).to receive(:new) do |options|
+          expect(options[:directory]).to eq(%w(app spec))
+          forwarder
+        end
+        described_class.start(options)
+      end
+    end
+  end
+
   describe 'relative option' do
     context 'without relative option' do
       let(:options) { %w[] }


### PR DESCRIPTION
The `listen` script can now take multiple directories

I encountered the duplicate directories problem in my Rails project (a
vendor gem used symlinks) so the simplest solution was not to watch the
whole project directory (i.e., the default —directories option) but
just the directories I care about. That meant I needed to watch
multiple directories which listen supports but the `listen` script did
not.

This commit changes the `-d` option type from string to array and adds
the appropriate specs. The order of the options doesn’t matter: `listen
-d app spec -v -r` is the same as `listen -v -r -d app spec` and then
directories `app` and `spec` are pass to `Listen.to` as an array