### PR TITLE
Anticipate Celluloid::FSM breaking off into its own gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ end
 
 group :test do
   gem 'celluloid', github: 'celluloid/celluloid', branch: '0-16-stable'
+  gem 'celluloid-fsm', github: 'celluloid/celluloid-fsm', branch: 'master'
   gem 'celluloid-io', '>= 0.15.0'
   gem 'rake'
   gem 'rspec', '~> 3.0.0rc1'

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -8,6 +8,8 @@ require 'listen/silencer'
 require 'listen/queue_optimizer'
 require 'English'
 
+require 'celluloid/fsm'
+
 require 'listen/internals/logging'
 
 module Listen


### PR DESCRIPTION
This will change to a static ( non-github ) rubygems reference, and is not intended to be merged right away. This is anticipating celluloid/celluloid#547, when `Celluloid::FSM` is no longer in `Celluloid` core, and is moved out into its own gem [celluloid-fsm](/celluloid/celluloid-fsm) ( currently in prerelease also ).