### PR TITLE
fixed ruby-1.9.3 parser issue for rdoc creation

### DIFF
--- a/lib/listen/logger.rb
+++ b/lib/listen/logger.rb
@@ -23,7 +23,7 @@ module Listen
   end
 
   class Logger
-    %i(fatal error warn info debug).each do |meth|
+    [:fatal, :error, :warn, :info, :debug].each do |meth|
       define_singleton_method(meth) do |*args, &block|
         Listen.logger.public_send(meth, *args, &block) if Listen.logger
       end


### PR DESCRIPTION
Please find the below description of the error.

RDoc::Parser::Ruby failure around line 26 of
lib/listen/logger.rb

Before reporting this, could you check that the file you're documenting
has proper syntax:

.rvm/rubies/ruby-1.9.3-p194/bin/ruby -c lib/listen/logger.rb
RDoc is not a full Ruby parser and will fail when fed invalid ruby programs.

The internal error was:
(RDoc::Error) unknown type of %string "i"
ERROR:  While generating documentation for listen-3.0.0
MESSAGE:   unknown type of %string "i"
