### PR TITLE
Avoid Kernel.require

### DIFF
--- a/lib/listen/adapter/linux.rb
+++ b/lib/listen/adapter/linux.rb
@@ -27,7 +27,7 @@ module Listen
       EOS
 
       def _configure(directory, &callback)
-        Kernel.require 'rb-inotify'
+        require 'rb-inotify'
         @worker ||= ::INotify::Notifier.new
         @worker.watch(directory.to_s, *options.events, &callback)
       rescue Errno::ENOSPC


### PR DESCRIPTION
...so we can load rb-inotify without explicit RUBYLIB path.

This fixes https://github.com/guard/listen/issues/340 and fixes the program itself.