### PR TITLE
fix failing specs on Travis+OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,6 @@ os:
   - linux
   - osx
 env:
-  - LISTEN_TESTS_DEFAULT_LAG=0.8
+  # TODO: 0.8 is enough on Linux, but 2 seems needed for Travis/OSX
+  - LISTEN_TESTS_DEFAULT_LAG=2
 sudo: false

--- a/spec/lib/listen/adapter/linux_spec.rb
+++ b/spec/lib/listen/adapter/linux_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe Listen::Adapter::Linux do
       let(:adapter_options) { { events: [:recursive, :close_write] } }
 
       before do
-        allow(Kernel).to receive(:require).with('rb-inotify')
         fake_worker = double(:fake_worker)
         events = [:recursive, :close_write]
         allow(fake_worker).to receive(:watch).with('/foo/dir1', *events)
@@ -78,6 +77,7 @@ RSpec.describe Listen::Adapter::Linux do
         allow(Listen::Change).to receive(:new).with(config, record).
           and_return(snapshot)
 
+        allow(subject).to receive(:require).with('rb-inotify')
         subject.configure
       end
 

--- a/spec/support/acceptance_helper.rb
+++ b/spec/support/acceptance_helper.rb
@@ -201,7 +201,6 @@ class ListenerWrapper
       # Lag should include:
       #  0.1s - 0.2s if the test needs Listener queue to be processed
       #  0.1s in case the system is busy
-      #  0.1s - for celluloid overhead and scheduling
       sleep lag
     end
 
@@ -228,9 +227,6 @@ class ListenerWrapper
     freeze_offset = @timed_changes.freeze_offset
 
     msg = "Changes took #{change_offset}s (allowed lag: #{freeze_offset})s"
-
-    # Use STDERR (workaround for Celluloid, since it catches abort)
-    STDERR.puts msg
     abort(msg)
   end
 
@@ -258,9 +254,8 @@ def _sleep_to_separate_events
   # separate the events or Darwin and Polling
   # will detect only the :added event
   #
-  # (This is because both use directory scanning
-  # through Celluloid tasks, which may not kick in
-  # time before the next filesystem change)
+  # (This is because both use directory scanning which may not kick in time
+  # before the next filesystem change)
   #
   # The minimum for this is the time it takes between a syscall
   # changing the filesystem ... and ... an async


### PR DESCRIPTION
0.8 works for Linux, but ~1.5 is needed on current Travis OSX builds