### PR TITLE
stop sharing mutable var among threads [fix #351]

### DIFF
--- a/lib/listen/adapter/darwin.rb
+++ b/lib/listen/adapter/darwin.rb
@@ -16,32 +16,27 @@ module Listen
       # NOTE: each directory gets a DIFFERENT callback!
       def _configure(dir, &callback)
         require 'rb-fsevent'
+
         opts = { latency: options.latency }
 
         @workers ||= ::Queue.new
         @workers << FSEvent.new.tap do |worker|
+          _log :debug, "fsevent: watching: #{dir.to_s.inspect}"
           worker.watch(dir.to_s, opts, &callback)
         end
       end
 
-      # NOTE: _run is called within a thread, so run every other
-      # worker in it's own thread
       def _run
         first = @workers.pop
-        until @workers.empty?
-          next_worker = @workers.pop
-          Listen::Internals::ThreadPool.add do
-            begin
-              next_worker.run
-            rescue
-              _log_exception 'run() in extra thread(s) failed: %s: %s'
-            end
-          end
-        end
-        first.run
+
+        # NOTE: _run is called within a thread, so run every other
+        # worker in it's own thread
+        _run_workers_in_background(_to_array(@workers))
+        _run_worker(first)
       end
 
       def _process_event(dir, event)
+        _log :debug, "fsevent: processing event: #{event.inspect}"
         event.each do |path|
           new_path = Pathname.new(path.sub(/\/$/, ''))
           _log :debug, "fsevent: #{new_path}"
@@ -49,6 +44,27 @@ module Listen
           rel_path = new_path.relative_path_from(dir).to_s
           _queue_change(:dir, dir, rel_path, recursive: true)
         end
+      end
+
+      def _run_worker(worker)
+        _log :debug, "fsevent: running worker: #{worker.inspect}"
+        worker.run
+      rescue
+        _log_exception 'fsevent: running worker failed: %s: %s'
+      end
+
+      def _run_workers_in_background(workers)
+        workers.each do |worker|
+          # NOTE: while passing local variables to the block below is not
+          # thread safe, using 'worker' from the enumerator above is ok
+          Listen::Internals::ThreadPool.add { _run_worker(worker) }
+        end
+      end
+
+      def _to_array(queue)
+        workers = []
+        workers << queue.pop until queue.empty?
+        workers
       end
     end
   end


### PR DESCRIPTION
Since the local variable 'worker' was modified on each iteration, some
threads "caught" the value in the wrong state.

Using an array with an enumerator guarantees each thread receives a
block with a separate copy of the variable.