### PR TITLE
use ruby_dep for gemspec Ruby version constraint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - gem install ruby_dep
   - gem update ruby_dep
 rvm:
-  - 2.2.2
+  - 2.2.4
   - jruby-head
   - rbx-2
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ bundler_args: --without development
 before_install:
   - gem install bundler
   - gem update bundler
+  - gem install ruby_dep
+  - gem update ruby_dep
 rvm:
   - 2.2.2
   - jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
 os:
   - linux
   - osx
+osx_image: xcode7.1
 env:
   # TODO: 0.8 is enough on Linux, but 2 seems needed for Travis/OSX
   - LISTEN_TESTS_DEFAULT_LAG=2

--- a/listen.gemspec
+++ b/listen.gemspec
@@ -3,29 +3,6 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'listen/version'
 
-require 'yaml'
-
-def ruby_version_constraint(filename = '.travis.yml')
-  yaml = YAML.load(IO.read(filename))
-  failable = yaml['matrix']['allow_failures'].map(&:values).flatten
-  versions = yaml['rvm'] - failable
-
-  by_major = versions.map do |x|
-    Gem::Version.new(x).segments[0..2]
-  end.group_by(&:first)
-
-  last_supported_major = by_major.keys.sort.last
-  selected = by_major[last_supported_major].sort.reverse
-
-  lowest = selected.shift
-  current = lowest[1]
-  while( lower = selected.shift)
-    (current -= 1) == lower[1] ? lowest = lower : break
-  end
-
-  ["~> #{lowest[0..1].join('.')}", ">= #{lowest.join('.')}"]
-end
-
 Gem::Specification.new do |s|
   s.name        = 'listen'
   s.version     = Listen::VERSION
@@ -45,10 +22,17 @@ Gem::Specification.new do |s|
   s.executable   = 'listen'
   s.require_path = 'lib'
 
-  s.required_ruby_version = ruby_version_constraint
+  begin
+    # TODO: should this be vendored instead?
+    require "ruby_dep/travis"
+    s.required_ruby_version = RubyDep::Travis.new.version_constraint
+  rescue LoadError
+    abort "Install 'ruby_dep' gem before building this gem"
+  end
 
   s.add_dependency 'rb-fsevent', '>= 0.9.3'
   s.add_dependency 'rb-inotify', '>= 0.9.7'
 
   s.add_development_dependency 'bundler', '>= 1.3.5'
+  s.add_development_dependency 'ruby_dep', '~> 1.0'
 end


### PR DESCRIPTION
This allows limiting officially supported Ruby versions to a "sane" list
extracted from the .travis.yml file.