### PR TITLE
warn users if their Ruby is outdated or insecure

### DIFF
--- a/lib/listen.rb
+++ b/lib/listen.rb
@@ -4,6 +4,11 @@ require 'listen/listener'
 
 require 'listen/internals/thread_pool'
 
+# Show warnings about vulnerabilities, bugs and outdated Rubies, since previous
+# versions aren't tested or officially supported.
+require 'ruby_dep/warning'
+RubyDep::Warning.new.show_warnings
+
 # Always set up logging by default first time file is required
 #
 # NOTE: If you need to clear the logger completely, do so *after*

--- a/listen.gemspec
+++ b/listen.gemspec
@@ -33,6 +33,9 @@ Gem::Specification.new do |s|
   s.add_dependency 'rb-fsevent', '>= 0.9.3'
   s.add_dependency 'rb-inotify', '>= 0.9.7'
 
+  # Used to show warnings at runtime
+  s.add_dependency 'ruby_dep', '~> 1.1'
+
   s.add_development_dependency 'bundler', '>= 1.3.5'
-  s.add_development_dependency 'ruby_dep', '~> 1.0'
+  s.add_development_dependency 'ruby_dep', '~> 1.1'
 end


### PR DESCRIPTION
Show warnings if Ruby version isn't up-to-date and offically
supported on ruby-lang.org.