### PR TITLE
Make rubocop pass on the .gemspec file

### DIFF
--- a/listen.gemspec
+++ b/listen.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   begin
     # TODO: should this be vendored instead?
-    require "ruby_dep/travis"
+    require 'ruby_dep/travis'
     s.required_ruby_version = RubyDep::Travis.new.version_constraint
   rescue LoadError
     abort "Install 'ruby_dep' gem before building this gem"


### PR DESCRIPTION
Rubocop expects a single quote, and was throwing a warning on this line.