### PR TITLE
Misc fixes to get JRuby working on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - 2.2.4
   - jruby-head
   - rbx-2
+  - jruby-9.0.5.0
 matrix:
   allow_failures:
     - rvm: jruby-head

--- a/lib/listen/adapter/linux.rb
+++ b/lib/listen/adapter/linux.rb
@@ -35,7 +35,9 @@ module Listen
       end
 
       def _run
+        Thread.current[:listen_blocking_read_thread] = true
         @worker.run
+        Thread.current[:listen_blocking_read_thread] = false
       end
 
       def _process_event(dir, event)

--- a/lib/listen/directory.rb
+++ b/lib/listen/directory.rb
@@ -80,7 +80,7 @@ module Listen
       # https://github.com/jruby/jruby/issues/3840
       exists = path.exist?
       directory = path.directory?
-      return path.children unless (exists && !directory)
+      return path.children unless exists && !directory
       raise Errno::ENOTDIR, path.to_s
     end
   end

--- a/lib/listen/internals/thread_pool.rb
+++ b/lib/listen/internals/thread_pool.rb
@@ -13,8 +13,16 @@ module Listen
         return if @threads.empty? # return to avoid using possibly stubbed Queue
 
         killed = Queue.new
+        # You can't kill a read on a descriptor in JRuby, so let's just
+        # ignore running threads (listen rb-inotify waiting for disk activity
+        # before closing)  pray threads die faster than they are created...
+        limit = RUBY_ENGINE == 'jruby' ? [1] : []
+
         killed << @threads.pop.kill until @threads.empty?
-        killed.pop.join until killed.empty?
+        until killed.empty?
+          th = killed.pop
+          th.join(*limit) unless th[:listen_blocking_read_thread]
+        end
       end
     end
   end

--- a/lib/listen/record/entry.rb
+++ b/lib/listen/record/entry.rb
@@ -15,7 +15,7 @@ module Listen
 
       def children
         child_relative = _join
-        (Dir.entries(sys_path) - %w(. ..)).map do |name|
+        (_entries(sys_path) - %w(. ..)).map do |name|
           Entry.new(@root, child_relative, name)
         end
       end
@@ -47,6 +47,17 @@ module Listen
       def _join
         args = [@relative, @name].compact
         args.empty? ? nil : ::File.join(*args)
+      end
+
+      def _entries(dir)
+        return Dir.entries(dir) unless RUBY_ENGINE == 'jruby'
+
+        # JRuby inconsistency workaround, see:
+        # https://github.com/jruby/jruby/issues/3840
+        exists = ::File.exist?(dir)
+        directory = ::File.directory?(dir)
+        return Dir.entries(dir) unless (exists && !directory)
+        raise Errno::ENOTDIR, dir
       end
     end
   end

--- a/lib/listen/record/entry.rb
+++ b/lib/listen/record/entry.rb
@@ -56,7 +56,7 @@ module Listen
         # https://github.com/jruby/jruby/issues/3840
         exists = ::File.exist?(dir)
         directory = ::File.directory?(dir)
-        return Dir.entries(dir) unless (exists && !directory)
+        return Dir.entries(dir) unless exists && !directory
         raise Errno::ENOTDIR, dir
       end
     end

--- a/listen.gemspec
+++ b/listen.gemspec
@@ -30,11 +30,11 @@ Gem::Specification.new do |s|
     abort "Install 'ruby_dep' gem before building this gem"
   end
 
-  s.add_dependency 'rb-fsevent', '>= 0.9.3'
-  s.add_dependency 'rb-inotify', '>= 0.9.7'
+  s.add_dependency 'rb-fsevent', '~> 0.9', '>= 0.9.7'
+  s.add_dependency 'rb-inotify', '~> 0.9', '>= 0.9.7'
 
   # Used to show warnings at runtime
-  s.add_dependency 'ruby_dep', '~> 1.1'
+  s.add_dependency 'ruby_dep', '~> 1.2'
 
-  s.add_development_dependency 'bundler', '>= 1.3.5'
+  s.add_development_dependency 'bundler', '~> 1.12'
 end


### PR DESCRIPTION
Workarounds/fixes:

- update gemspec dependencies (for newer Bundler resoler and RubyDep JRuby
    support)

- get JRuby to fail with ENOTDIR like MRI does (because JRuby reports ENOENT,
    while Listen treats both differently)

- avoid unkillable thread problem on JRuby (which until now cause every Travis build to hang forever)

- activate JRuby-9.0.5.0 on Travis (since once it works, it can be officially considered as "supported" by Listen)

Not fixed yet: 

- crash-free closing in rb-inotify (https://github.com/nex3/rb-inotify/pull/53, (...)) - needs a release or two there

- some integration tests failing (changes based on snapshot differences somehow don't make it in time)