### PR TITLE
Change rb-fsevent dependency to work on OS X 10.6-10.8

### DIFF
--- a/listen.gemspec
+++ b/listen.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
     abort "Install 'ruby_dep' gem before building this gem"
   end
 
-  s.add_dependency 'rb-fsevent', '~> 0.9', '>= 0.9.7'
+  s.add_dependency 'rb-fsevent', '~> 0.9', '>= 0.9.4'
   s.add_dependency 'rb-inotify', '~> 0.9', '>= 0.9.7'
 
   # Used to show warnings at runtime


### PR DESCRIPTION
Change `rb-fsevent` dependency from `>= 0.9.7` to `>= 0.9.4`, to enable gem to work on OS X 10.6 through 10.8.

Needed as `rb-fsevent > 0.9.4` no longer supports OS X 10.6 through 10.8.

Tested on OS X 10.8 via use with `guard-rspec` gem.

Fixes #392
