### PR TITLE
Backport various bugfixes up to Listen 3.1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
 os:
   - linux
   - osx
+osx_image: xcode7.1
 env:
   # TODO: 0.8 is enough on Linux, but 2 seems needed for Travis/OSX
   - LISTEN_TESTS_DEFAULT_LAG=2

--- a/lib/listen/adapter/linux.rb
+++ b/lib/listen/adapter/linux.rb
@@ -101,7 +101,7 @@ module Listen
       end
 
       def _stop
-        @worker.close
+        @worker && @worker.close
       end
     end
   end

--- a/lib/listen/adapter/linux.rb
+++ b/lib/listen/adapter/linux.rb
@@ -35,7 +35,9 @@ module Listen
       end
 
       def _run
+        Thread.current[:listen_blocking_read_thread] = true
         @worker.run
+        Thread.current[:listen_blocking_read_thread] = false
       end
 
       def _process_event(dir, event)

--- a/lib/listen/backend.rb
+++ b/lib/listen/backend.rb
@@ -2,6 +2,8 @@ require 'listen/adapter'
 require 'listen/adapter/base'
 require 'listen/adapter/config'
 
+require 'forwardable'
+
 # This class just aggregates configuration object to avoid Listener specs
 # from exploding with huge test setup blocks
 module Listen

--- a/lib/listen/event/queue.rb
+++ b/lib/listen/event/queue.rb
@@ -1,5 +1,7 @@
 require 'thread'
 
+require 'forwardable'
+
 module Listen
   module Event
     class Queue

--- a/lib/listen/internals/thread_pool.rb
+++ b/lib/listen/internals/thread_pool.rb
@@ -13,8 +13,16 @@ module Listen
         return if @threads.empty? # return to avoid using possibly stubbed Queue
 
         killed = Queue.new
+        # You can't kill a read on a descriptor in JRuby, so let's just
+        # ignore running threads (listen rb-inotify waiting for disk activity
+        # before closing)  pray threads die faster than they are created...
+        limit = RUBY_ENGINE == 'jruby' ? [1] : []
+
         killed << @threads.pop.kill until @threads.empty?
-        killed.pop.join until killed.empty?
+        until killed.empty?
+          th = killed.pop
+          th.join(*limit) unless th[:listen_blocking_read_thread]
+        end
       end
     end
   end

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -61,7 +61,7 @@ module Listen
 
     default_state :initializing
 
-    state :initializing, to: :backend_started
+    state :initializing, to: [:backend_started, :stopped]
 
     state :backend_started, to: [:frontend_ready, :stopped] do
       backend.start

--- a/lib/listen/record/entry.rb
+++ b/lib/listen/record/entry.rb
@@ -13,7 +13,7 @@ module Listen
 
       def children
         child_relative = _join
-        (Dir.entries(sys_path) - %w(. ..)).map do |name|
+        (_entries(sys_path) - %w(. ..)).map do |name|
           Entry.new(@root, child_relative, name)
         end
       end
@@ -45,6 +45,17 @@ module Listen
       def _join
         args = [@relative, @name].compact
         args.empty? ? nil : ::File.join(*args)
+      end
+
+      def _entries(dir)
+        return Dir.entries(dir) unless RUBY_ENGINE == 'jruby'
+
+        # JRuby inconsistency workaround, see:
+        # https://github.com/jruby/jruby/issues/3840
+        exists = ::File.exist?(dir)
+        directory = ::File.directory?(dir)
+        return Dir.entries(dir) unless (exists && !directory)
+        raise Errno::ENOTDIR, dir
       end
     end
   end

--- a/listen.gemspec
+++ b/listen.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency 'rb-fsevent', '>= 0.9.3'
-  s.add_dependency 'rb-inotify', '>= 0.9.7'
+  s.add_dependency 'rb-fsevent', '~> 0.9', '>= 0.9.4'
+  s.add_dependency 'rb-inotify', '~> 0.9', '>= 0.9.7'
 
   s.add_development_dependency 'bundler', '>= 1.3.5'
 end

--- a/spec/lib/listen/adapter/linux_spec.rb
+++ b/spec/lib/listen/adapter/linux_spec.rb
@@ -131,24 +131,37 @@ RSpec.describe Listen::Adapter::Linux do
       let(:adapter_options) { { events: [:recursive, :close_write] } }
 
       before do
-        events = [:recursive, :close_write]
-        allow(fake_worker).to receive(:watch).with('/foo/dir1', *events)
-
-        fake_notifier = double(:fake_notifier, new: fake_worker)
-        stub_const('INotify::Notifier', fake_notifier)
-
         allow(config).to receive(:directories).and_return(directories)
         allow(config).to receive(:adapter_options).and_return(adapter_options)
-        allow(config).to receive(:queue).and_return(queue)
-        allow(config).to receive(:silencer).and_return(silencer)
-
-        allow(subject).to receive(:require).with('rb-inotify')
-        subject.configure
       end
 
-      it 'stops the worker' do
-        expect(fake_worker).to receive(:close)
-        subject.stop
+      context 'when configured' do
+        before do
+          events = [:recursive, :close_write]
+          allow(fake_worker).to receive(:watch).with('/foo/dir1', *events)
+
+          fake_notifier = double(:fake_notifier, new: fake_worker)
+          stub_const('INotify::Notifier', fake_notifier)
+
+          allow(config).to receive(:queue).and_return(queue)
+          allow(config).to receive(:silencer).and_return(silencer)
+
+          allow(subject).to receive(:require).with('rb-inotify')
+          subject.configure
+        end
+
+        it 'stops the worker' do
+          expect(fake_worker).to receive(:close)
+          subject.stop
+        end
+      end
+
+      context 'when not even initialized' do
+        it 'does not crash' do
+          expect do
+            subject.stop
+          end.to_not raise_error
+        end
       end
     end
   end

--- a/spec/lib/listen/listener_spec.rb
+++ b/spec/lib/listen/listener_spec.rb
@@ -175,6 +175,18 @@ RSpec.describe Listener do
         subject.stop
       end
     end
+
+    context 'when only initialized' do
+      before do
+        subject
+      end
+
+      it 'terminates' do
+        allow(backend).to receive(:stop)
+        allow(processor).to receive(:teardown)
+        subject.stop
+      end
+    end
   end
 
   describe '#pause' do

--- a/spec/lib/listen/listener_spec.rb
+++ b/spec/lib/listen/listener_spec.rb
@@ -85,8 +85,8 @@ RSpec.describe Listener do
 
     context 'with a block' do
       let(:myblock) { instance_double(Proc) }
-      let(:block) { proc { myblock.call }  }
-      subject { described_class.new('dir1', &block) }
+      let(:real_block) { proc { myblock.call }  }
+      subject { described_class.new('dir1', &real_block) }
 
       it 'passes the block to the event processor' do
         allow(Event::Config).to receive(:new) do |*_args, &some_block|


### PR DESCRIPTION
Bugfixes:

- prevent crash when stopping uninitialized listener
- prevent crash when stopping uninitialized adapter
- #392 - Change rb-fsevent dependency to work on OS X 10.6-10.8
- get JRuby to fail with ENOTDIR like MRI does
- avoid unkillable thread problem on JRuby
- explicity require forwardable

Development:

- use OSX 10.10 on travis for precompiled Ruby 2.2.4
- fix broken spec (let block name conflict)