### PR TITLE
[ci skip] Document behavior in forked environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ The Listen gem listens to file modifications and notifies you about the changes.
 * Specs suite on JRuby and Rubinius aren't reliable on Travis CI, but should work.
 * Windows and \*BSD adapter aren't continuously and automatically tested.
 * OSX adapter has some performance limitations ([#342](https://github.com/guard/listen/issues/342)).
-* Ruby < 2.2.x is no longer supported - upgrade to Ruby 2.2 or 2.3
+* Ruby < 2.2.x is no longer supported - upgrade to Ruby 2.2 or 2.3.
+* Listeners do not notify across forked processes, if you wish for multiple processes to receive change notifications you must [listen inside of each process](https://github.com/guard/listen/issues/398#issuecomment-223957952).
 
 Pull requests or help is very welcome for these.
 
@@ -170,7 +171,7 @@ polling_fallback_message: 'custom message'      # Set a custom polling fallback 
 
 ## Debugging
 
-Setting the environment variable `LISTEN_GEM_DEBUGGING=1` sets up the INFO level logger, while `LISTEN_GEM_DEBUGGING=2` sets up the DEBUG level logger. 
+Setting the environment variable `LISTEN_GEM_DEBUGGING=1` sets up the INFO level logger, while `LISTEN_GEM_DEBUGGING=2` sets up the DEBUG level logger.
 
 You can also set `Listen.logger` to a custom logger.
 


### PR DESCRIPTION
A follow up from #398 to mention behavior across multiple processes.