### PR TITLE
Pin ruby_dep to ~> 1.2.0

### DIFF
--- a/listen.gemspec
+++ b/listen.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rb-inotify', '~> 0.9', '>= 0.9.7'
 
   # Used to show warnings at runtime
-  s.add_dependency 'ruby_dep', '~> 1.2'
+  s.add_dependency 'ruby_dep', '~> 1.2.0'
 
   s.add_development_dependency 'bundler', '~> 1.12'
 end


### PR DESCRIPTION
The pin on ~> 1.2 resolves ruby_dep to the major version update released on august 3 (1.4.0), which has a dependency on ruby 2.2.5. This pull request fixes that.