### PR TITLE
Don't require rb-fsevent until actually needed

### DIFF
--- a/lib/listen/adapter/darwin.rb
+++ b/lib/listen/adapter/darwin.rb
@@ -22,11 +22,11 @@ module Listen
       EOS
 
       def self.usable?
-        require 'rb-fsevent'
         version = RbConfig::CONFIG['target_os'][OS_REGEXP, :major_version]
         return false unless version
         return true if version.to_i >= 13 # darwin13 is OS X 10.9
 
+        require 'rb-fsevent'
         fsevent_version = Gem::Version.new(FSEvent::VERSION)
         return true if fsevent_version <= Gem::Version.new('0.9.4')
         Kernel.warn INCOMPATIBLE_GEM_VERSION


### PR DESCRIPTION
rb-fsevent is used only on macOS. If you somehow exclude it from
dependencies on other platforms, for example to avoid unnecessary
complications with building native extensions, then "listen" fails to
start just because it's required before checked that it's not usable on
the current platform. This patch fixes this error.

See also #416

**NOTE:** Travis build does _not_ fail because of this change.