### PR TITLE
Require rb-fsevent when needed, in _configure method

### DIFF
--- a/lib/listen/adapter/darwin.rb
+++ b/lib/listen/adapter/darwin.rb
@@ -37,6 +37,7 @@ module Listen
 
       # NOTE: each directory gets a DIFFERENT callback!
       def _configure(dir, &callback)
+        require 'rb-fsevent'
         opts = { latency: options.latency }
 
         @workers ||= ::Queue.new


### PR DESCRIPTION
This fixes an error I’ve introduced in #417, sorry for that.

The problem is: when the OS version is >= 13, then it early returns from the `usable?` function and does not require `rb-fsevent`.

```rb
      def self.usable?
        version = RbConfig::CONFIG['target_os'][OS_REGEXP, :major_version]
        return false unless version
        return true if version.to_i >= 13
        # ^--- HERE

        require 'rb-fsevent'
        ...
```