### PR TITLE
Update .travis.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ bundle
 .rvmrc
 .vagrant
 Gemfile.lock
+Gemfile.ruby_dep.lock
 spec/.fixtures
 coverage
 .ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,30 @@ bundler_args: --without development
 before_install:
   - gem install bundler
   - gem update bundler
-  - gem install ruby_dep
-  - gem update ruby_dep
+  - bundle install --gemfile=Gemfile.ruby_dep --path vendor/bundle
 rvm:
-  - 2.2.5
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
+  - ruby-head
   - jruby-head
   - rbx-2
   - jruby-9.1.2.0
 matrix:
   allow_failures:
+    - rvm: ruby-head
     - rvm: jruby-head
     - rvm: rbx-2
   exclude:
+    - rvm: 2.3.4
+      os: osx
+    - rvm: 2.4.1
+      os: osx
     - rvm: jruby-head
       os: osx
     - rvm: rbx-2
       os: osx
+  fast_finish: true
 os:
   - linux
   - osx

--- a/Gemfile.ruby_dep
+++ b/Gemfile.ruby_dep
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'ruby_dep'


### PR DESCRIPTION
* I updated Rubies to latest version.
* I also added `ruby-head` as `allow_failures`.

I think adding `ruby-head` is useful. 
Because we can prepare before next version Ruby 2.5 release.
Though it might not be useful until the actual preview release.
We can support the next version as faster.

We can see this kind of logic in `rails`, `rspec` and `cucumber` and etc.
https://github.com/rails/rails/blob/master/.travis.yml
https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://github.com/cucumber/cucumber-ruby/blob/master/.travis.yml

Is it possible to merge?

Thanks.
