### PR TITLE
Tighten version constraint for rb-fsevent

### DIFF
--- a/listen.gemspec
+++ b/listen.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
     abort "Install 'ruby_dep' gem before building this gem"
   end
 
-  s.add_dependency 'rb-fsevent', '~> 0.9.0', '>= 0.9.4'
+  s.add_dependency 'rb-fsevent', '~> 0.10', '>= 0.10.2'
   s.add_dependency 'rb-inotify', '~> 0.9', '>= 0.9.7'
 
   # Used to show warnings at runtime

--- a/listen.gemspec
+++ b/listen.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
     abort "Install 'ruby_dep' gem before building this gem"
   end
 
-  s.add_dependency 'rb-fsevent', '~> 0.9', '>= 0.9.4'
+  s.add_dependency 'rb-fsevent', '~> 0.9.0', '>= 0.9.4'
   s.add_dependency 'rb-inotify', '~> 0.9', '>= 0.9.7'
 
   # Used to show warnings at runtime


### PR DESCRIPTION
Using version `0.10.x` of `rb-fsevent` is causing exceptions such as this:

`fsevent: running worker failed: wrong number of arguments (given 2, expected 1)`

Locking to 0.9.x should fix this until the compatibility issue is solved.

Update: 0.10.2 fixes the bug so I have updated my branch to reflect this