### PR TITLE
⚠ assigned but unused variable - from_change, to_change

### DIFF
--- a/lib/listen/queue_optimizer.rb
+++ b/lib/listen/queue_optimizer.rb
@@ -107,15 +107,15 @@ module Listen
     def _detect_possible_editor_save(changes)
       return unless changes.size == 2
 
-      from_type = from_change = from = nil
-      to_type = to_change = to_dir = to = nil
+      from_type = from = nil
+      to_type = to_dir = to = nil
 
       changes.each do |data|
         case data[1]
         when :moved_from
-          from_type, from_change, _, from, = data
+          from_type, _from_change, _, from, = data
         when :moved_to
-          to_type, to_change, to_dir, to, = data
+          to_type, _to_change, to_dir, to, = data
         else
           return nil
         end


### PR DESCRIPTION
Current 3.1.5 gem prints "assigned but unused variable" warnings with Ruby 2.5.
```
% ruby -vrlisten -e ''
ruby 2.5.0dev (2017-10-20 trunk 60219) [x86_64-darwin15]
.../ruby/gems/2.5.0/gems/listen-3.1.5/lib/listen/queue_optimizer.rb:110: warning: assigned but unused variable - from_change
.../ruby/gems/2.5.0/gems/listen-3.1.5/lib/listen/queue_optimizer.rb:111: warning: assigned but unused variable - to_change
```

Here's a fix.