### PR TITLE
Attempt at fixing TravisCI build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ bundle
 .rvmrc
 .vagrant
 Gemfile.lock
-Gemfile.ruby_dep.lock
 spec/.fixtures
 coverage
 .ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ bundler_args: --without development
 before_install:
   - gem install bundler
   - gem update bundler
-  - bundle install --gemfile=Gemfile.ruby_dep --path vendor/bundle
+  - bundle install --path vendor/bundle
 rvm:
   - 2.2.7
   - 2.3.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,22 +5,23 @@ before_install:
   - gem update bundler
   - bundle install --path vendor/bundle
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2.9
+  - 2.3.6
+  - 2.4.3
+  - 2.5.0
   - ruby-head
   - jruby-head
   - rbx-2
-  - jruby-9.1.2.0
+  - jruby-9.1.15.0
 matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
     - rvm: rbx-2
   exclude:
-    - rvm: 2.3.4
+    - rvm: 2.3.6
       os: osx
-    - rvm: 2.4.1
+    - rvm: 2.4.3
       os: osx
     - rvm: jruby-head
       os: osx

--- a/Gemfile.ruby_dep
+++ b/Gemfile.ruby_dep
@@ -1,3 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'ruby_dep'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 ## IMPORTANT: [Ruby 2.1 is officially outdated and unsupported!](https://www.ruby-lang.org/en/news/2016/03/30/ruby-2-1-9-released/) Please upgrade to Ruby 2.2.5 before installing Listen!
 
-## IMPORTANT: If you cannot upgrade to Ruby >= 2.2.5 [solutions are listed here](https://github.com/e2/ruby_dep#important--how-to-correctly-solve-issues)
-
 ## IMPORTANT: If you cannot install Listen (e.g. on Travis/CI builds), [a workaround is here](https://github.com/guard/listen/wiki/Ruby-version-requirements)
 
 :exclamation: Listen is currently accepting more maintainers. Please [read this](https://github.com/guard/guard/wiki/Maintainers) if you're interested in joining the team.

--- a/lib/listen.rb
+++ b/lib/listen.rb
@@ -4,11 +4,6 @@ require 'listen/listener'
 
 require 'listen/internals/thread_pool'
 
-# Show warnings about vulnerabilities, bugs and outdated Rubies, since previous
-# versions aren't tested or officially supported.
-require 'ruby_dep/warning'
-RubyDep::Warning.new.show_warnings
-
 # Always set up logging by default first time file is required
 #
 # NOTE: If you need to clear the logger completely, do so *after*

--- a/listen.gemspec
+++ b/listen.gemspec
@@ -22,19 +22,10 @@ Gem::Specification.new do |s|
   s.executable   = 'listen'
   s.require_path = 'lib'
 
-  begin
-    # TODO: should this be vendored instead?
-    require 'ruby_dep/travis'
-    s.required_ruby_version = RubyDep::Travis.new.version_constraint
-  rescue LoadError
-    abort "Install 'ruby_dep' gem before building this gem"
-  end
+  s.required_ruby_version = "~> 2.2"
 
   s.add_dependency 'rb-fsevent', '~> 0.9', '>= 0.9.4'
   s.add_dependency 'rb-inotify', '~> 0.9', '>= 0.9.7'
-
-  # Used to show warnings at runtime
-  s.add_dependency 'ruby_dep', '~> 1.2'
 
   s.add_development_dependency 'bundler', '~> 1.12'
 end


### PR DESCRIPTION
It appears to be giving problems in TravisCI build due to the gem being outdated in terms of the supported ruby version listed there.
It doesn't seem that's been actively updated/maintained lately either.