### PR TITLE
Update dependencies and travis matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ bundle
 .rvmrc
 .vagrant
 Gemfile.lock
-Gemfile.ruby_dep.lock
 spec/.fixtures
 coverage
 .ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,13 @@ rvm:
   - 2.4.1
   - ruby-head
   - jruby-head
-  - rbx-2
+  - rbx-3
   - jruby-9.1.2.0
 matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    - rvm: rbx-2
+    - rvm: rbx-3
   exclude:
     - rvm: 2.3.4
       os: osx
@@ -24,7 +24,7 @@ matrix:
       os: osx
     - rvm: jruby-head
       os: osx
-    - rvm: rbx-2
+    - rvm: rbx-3
       os: osx
   fast_finish: true
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ before_install:
   - gem update bundler
   - bundle install
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
-  - 2.5.0
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
   - ruby-head
   - jruby-head
   - rbx-3

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ rvm:
   - ruby-head
   - jruby-head
   - rbx-3
-  - jruby-9.1.2.0
+  - jruby-9.2.0.0
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 bundler_args: --without development --path vendor/bundle
 before_install:
+  - gem update --system
   - gem install bundler
   - gem update bundler
   - bundle install
@@ -8,6 +9,7 @@ rvm:
   - 2.2.7
   - 2.3.4
   - 2.4.1
+  - 2.5.0
   - ruby-head
   - jruby-head
   - rbx-3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
-bundler_args: --without development
+bundler_args: --without development --path vendor/bundle
 before_install:
   - gem install bundler
   - gem update bundler
-  - bundle install --gemfile=Gemfile.ruby_dep --path vendor/bundle
+  - bundle install
 rvm:
   - 2.2.7
   - 2.3.4

--- a/Gemfile.ruby_dep
+++ b/Gemfile.ruby_dep
@@ -1,3 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'ruby_dep'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-## IMPORTANT: [Ruby 2.1 is officially outdated and unsupported!](https://www.ruby-lang.org/en/news/2016/03/30/ruby-2-1-9-released/) Please upgrade to Ruby 2.2.5 before installing Listen!
-
-## IMPORTANT: If you cannot upgrade to Ruby >= 2.2.5 [solutions are listed here](https://github.com/e2/ruby_dep#important--how-to-correctly-solve-issues)
-
 ## IMPORTANT: If you cannot install Listen (e.g. on Travis/CI builds), [a workaround is here](https://github.com/guard/listen/wiki/Ruby-version-requirements)
 
 :exclamation: Listen is currently accepting more maintainers. Please [read this](https://github.com/guard/guard/wiki/Maintainers) if you're interested in joining the team.

--- a/lib/listen.rb
+++ b/lib/listen.rb
@@ -4,11 +4,6 @@ require 'listen/listener'
 
 require 'listen/internals/thread_pool'
 
-# Show warnings about vulnerabilities, bugs and outdated Rubies, since previous
-# versions aren't tested or officially supported.
-require 'ruby_dep/warning'
-RubyDep::Warning.new.show_warnings
-
 # Always set up logging by default first time file is required
 #
 # NOTE: If you need to clear the logger completely, do so *after*

--- a/listen.gemspec
+++ b/listen.gemspec
@@ -22,19 +22,10 @@ Gem::Specification.new do |s|
   s.executable   = 'listen'
   s.require_path = 'lib'
 
-  begin
-    # TODO: should this be vendored instead?
-    require 'ruby_dep/travis'
-    s.required_ruby_version = RubyDep::Travis.new.version_constraint
-  rescue LoadError
-    abort "Install 'ruby_dep' gem before building this gem"
-  end
+  s.required_ruby_version = ['~> 2.2', '>= 2.2.7']
 
   s.add_dependency 'rb-fsevent', '~> 0.10', '>= 0.10.3'
   s.add_dependency 'rb-inotify', '~> 0.9', '>= 0.9.10'
-
-  # Used to show warnings at runtime
-  s.add_dependency 'ruby_dep', '~> 1.2'
 
   s.add_development_dependency 'bundler', '~> 1.12'
 end

--- a/spec/lib/listen/event/loop_spec.rb
+++ b/spec/lib/listen/event/loop_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Listen::Event::Loop do
   let(:blocks) do
     {
       thread_block: proc { fail 'thread block stub called' },
-      timer_block: proc { fail 'thread block stub called' },
+      timer_block: proc { fail 'thread block stub called' }
     }
   end
 

--- a/vendor/hound/config/style_guides/ruby.yml
+++ b/vendor/hound/config/style_guides/ruby.yml
@@ -13,7 +13,7 @@ Style/CollectionMethods:
     find: detect
     find_all: select
     reduce: inject
-Style/DotPosition:
+Layout/DotPosition:
   Description: Checks the position of the dot in multi-line method calls.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
   Enabled: true
@@ -21,7 +21,7 @@ Style/DotPosition:
   SupportedStyles:
   - leading
   - trailing
-Style/FileName:
+Naming/FileName:
   Description: Use snake_case for source file names.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-files
   Enabled: false
@@ -35,7 +35,6 @@ Style/IfUnlessModifier:
   Description: Favor modifier if/unless usage when you have a single-line body.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
   Enabled: false
-  MaxLineLength: 80
 Style/OptionHash:
   Description: Don't use option hashes when you can use keyword arguments.
   Enabled: false
@@ -53,7 +52,7 @@ Style/PercentLiteralDelimiters:
     "%w": "()"
     "%W": "()"
     "%x": "()"
-Style/PredicateName:
+Naming/PredicateName:
   Description: Check the names of predicate methods.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark
   Enabled: true
@@ -123,9 +122,16 @@ Style/TrailingCommaInArguments:
   - comma
   - consistent_comma
   - no_comma
-Style/TrailingCommaInLiteral:
-  Description: 'Checks for trailing comma in array and hash literals.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+Style/TrailingCommaInArrayLiteral:
+  Description: 'Checks for trailing comma in array literals.'
+  Enabled: false
+  EnforcedStyleForMultiline: no_comma
+  SupportedStyles:
+  - comma
+  - consistent_comma
+  - no_comma
+Style/TrailingCommaInHashLiteral:
+  Description: 'Checks for trailing comma in hash literals.'
   Enabled: false
   EnforcedStyleForMultiline: no_comma
   SupportedStyles:
@@ -177,7 +183,7 @@ Lint/AssignmentInCondition:
 Style/InlineComment:
   Description: Avoid inline comments.
   Enabled: false
-Style/AccessorMethodName:
+Naming/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
   Enabled: false
 Style/Alias:


### PR DESCRIPTION
* 38108c5 2018-06-03 | Replace jruby-9.1.2.0 by jruby-9.2.0.0 in the build matrix [Olle Jonsson]
* 913c166 2018-06-04 | Simplify the build matrix to use minor Ruby versions [Rémy Coutable]
* 736dd9c 2017-12-31 | Add Ruby 2.5.0 to the build matrix [Tsukuru Tanimichi]
* 1161552 2016-06-05 | Replace rbx-2 with rbx-3 in the build matrix [Omer Katz]
* 45802c5 2018-06-04 | Don't use RubyDep anymore since it's outdated and not very useful [Rémy Coutable]
