### PR TITLE
Fix: Tracking of removed subdirectories

### DIFF
--- a/lib/listen/record.rb
+++ b/lib/listen/record.rb
@@ -58,7 +58,7 @@ module Listen
 
     def _sub_tree(rel_path)
       tree.each_with_object({}) do |(path, meta), result|
-        next if !path.start_with?(rel_path)
+        next unless path.start_with?(rel_path)
 
         if path == rel_path
           result.merge!(meta)

--- a/lib/listen/record.rb
+++ b/lib/listen/record.rb
@@ -45,8 +45,7 @@ module Listen
         if [nil, '', '.'].include? rel_path.to_s
           tree
         else
-          tree[rel_path.to_s] ||= _auto_hash
-          tree[rel_path.to_s]
+          _sub_tree(rel_path)
         end
 
       result = {}
@@ -55,6 +54,19 @@ module Listen
         result[key] = values.key?(:mtime) ? values : {}
       end
       result
+    end
+
+    def _sub_tree(rel_path)
+      tree.each_with_object({}) do |(path, meta), result|
+        next if !path.start_with?(rel_path)
+
+        if path == rel_path
+          result.merge!(meta)
+        else
+          sub_path         = path.sub(%r{\A#{rel_path}/?}, '')
+          result[sub_path] = meta
+        end
+      end
     end
 
     def build

--- a/spec/acceptance/listen_spec.rb
+++ b/spec/acceptance/listen_spec.rb
@@ -200,16 +200,16 @@ RSpec.describe 'Listen', acceptance: true do
               mkdir_p 'dir1'
               mkdir_p 'dir1/subdir1'
               mkdir_p 'dir1/subdir1/subdir2'
-              touch 'dir1/subdir1/file1.rb'
-              touch 'dir1/subdir1/subdir2/file2.rb'
+              touch 'dir1/subdir1/file.rb'
+              touch 'dir1/subdir1/subdir2/file.rb'
               example.run
             end
 
             it 'listen to the files of a removed directory' do
               expected = {
                 modified: [],
-                added: [],
-                removed: ['dir1/subdir1/file1.rb', 'dir1/subdir1/subdir2/file2.rb']
+                added:    [],
+                removed:  %w(dir1/subdir1/file.rb dir1/subdir1/subdir2/file.rb)
               }
 
               expect(wrapper.listen do

--- a/spec/acceptance/listen_spec.rb
+++ b/spec/acceptance/listen_spec.rb
@@ -195,6 +195,29 @@ RSpec.describe 'Listen', acceptance: true do
             end
           end
 
+          context 'listens to subdirectory removed' do
+            around do |example|
+              mkdir_p 'dir1'
+              mkdir_p 'dir1/subdir1'
+              mkdir_p 'dir1/subdir1/subdir2'
+              touch 'dir1/subdir1/file1.rb'
+              touch 'dir1/subdir1/subdir2/file2.rb'
+              example.run
+            end
+
+            it 'listen to the files of a removed directory' do
+              expected = {
+                modified: [],
+                added: [],
+                removed: ['dir1/subdir1/file1.rb', 'dir1/subdir1/subdir2/file2.rb']
+              }
+
+              expect(wrapper.listen do
+                rm_rf 'dir1'
+              end).to eq expected
+            end
+          end
+
           context 'with .bundle dir ignored by default' do
             around do |example|
               mkdir_p '.bundle'

--- a/spec/lib/listen/record_spec.rb
+++ b/spec/lib/listen/record_spec.rb
@@ -217,6 +217,11 @@ RSpec.describe Listen::Record do
         before { record.update_file('path/file.rb', mtime: 1.1) }
         it { should eq('file.rb' => { mtime: 1.1 }) }
       end
+
+      context 'with path/subdir' do
+        before {record.add_dir('path/subdir')}
+        it { should eq('subdir' =>{}) }
+      end
     end
   end
 

--- a/spec/lib/listen/record_spec.rb
+++ b/spec/lib/listen/record_spec.rb
@@ -219,8 +219,8 @@ RSpec.describe Listen::Record do
       end
 
       context 'with path/subdir' do
-        before {record.add_dir('path/subdir')}
-        it { should eq('subdir' =>{}) }
+        before { record.add_dir('path/subdir') }
+        it { should eq('subdir' => {}) }
       end
     end
   end


### PR DESCRIPTION
Some MacOS commands weren't recognized by the listener. example: 
- ⌘command + delete 
- Retrieve directories from the recycling bin