### PR TITLE
WIP: Use NIO.2 WatchService for JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,28 +3,6 @@ cache: bundler
 
 matrix:
   include:
-    - rvm: 2.3
-    - rvm: 2.4
-    - rvm: 2.5
-    - rvm: 2.6
-    - rvm: 2.5
-      os: osx
-      env:
-        # TODO: 0.8 is enough on Linux, but 2 seems needed for Travis/OSX
-        - LISTEN_TESTS_DEFAULT_LAG=2
     - rvm: jruby
       env:
-        - LISTEN_TESTS_DEFAULT_LAG=10
         - TEST_LISTEN_ADAPTER_MODES=native
-        - LISTEN_GEM_DEBUGGING=2
-    - rvm: truffleruby
-    - rvm: jruby-head
-    - rvm: ruby-head
-    - rvm: rbx-3
-  allow_failures:
-    - rvm: truffleruby
-    - rvm: jruby
-    - rvm: ruby-head
-    - rvm: jruby-head
-    - rvm: rbx-3
-  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ matrix:
         # TODO: 0.8 is enough on Linux, but 2 seems needed for Travis/OSX
         - LISTEN_TESTS_DEFAULT_LAG=2
     - rvm: jruby
+      env:
+        - LISTEN_TESTS_DEFAULT_LAG=10
+        - TEST_LISTEN_ADAPTER_MODES=native
+        - LISTEN_GEM_DEBUGGING=2
     - rvm: truffleruby
     - rvm: jruby-head
     - rvm: ruby-head

--- a/lib/listen/adapter.rb
+++ b/lib/listen/adapter.rb
@@ -17,7 +17,11 @@ module Listen
         _log :debug, 'Adapter: considering polling ...'
         return Polling if options[:force_polling]
         _log :debug, 'Adapter: considering optimized backend...'
-        return _usable_adapter_class if _usable_adapter_class
+        _log :debug, "Adapter: RUBY_ENGINE=#{RUBY_ENGINE}"
+        if _usable_adapter_class
+          _log :debug, "Adapter: using #{_usable_adapter_class}"
+          return _usable_adapter_class
+        end
         _log :debug, 'Adapter: falling back to polling...'
         _warn_polling_fallback(options)
         Polling

--- a/lib/listen/adapter.rb
+++ b/lib/listen/adapter.rb
@@ -8,7 +8,7 @@ require 'listen/adapter/jruby'
 
 module Listen
   module Adapter
-    OPTIMIZED_ADAPTERS = [Darwin, Linux, BSD, Windows, Jruby].freeze
+    OPTIMIZED_ADAPTERS = [Jruby, Darwin, Linux, BSD, Windows].freeze
     POLLING_FALLBACK_MESSAGE = 'Listen will be polling for changes.'\
       'Learn more at https://github.com/guard/listen#listen-adapters.'.freeze
 

--- a/lib/listen/adapter.rb
+++ b/lib/listen/adapter.rb
@@ -4,10 +4,11 @@ require 'listen/adapter/darwin'
 require 'listen/adapter/linux'
 require 'listen/adapter/polling'
 require 'listen/adapter/windows'
+require 'listen/adapter/jruby'
 
 module Listen
   module Adapter
-    OPTIMIZED_ADAPTERS = [Darwin, Linux, BSD, Windows].freeze
+    OPTIMIZED_ADAPTERS = [Darwin, Linux, BSD, Windows, Jruby].freeze
     POLLING_FALLBACK_MESSAGE = 'Listen will be polling for changes.'\
       'Learn more at https://github.com/guard/listen#listen-adapters.'.freeze
 

--- a/lib/listen/adapter/jruby.rb
+++ b/lib/listen/adapter/jruby.rb
@@ -21,6 +21,7 @@ module Listen
         ]
 
         @watcher ||= FileSystems.getDefault.newWatchService
+        p @watcher.class.name
         @keys ||= {}
         path = Paths.get(directory.to_s)
         key = path.register(@watcher, *event_kinds)

--- a/lib/listen/adapter/jruby.rb
+++ b/lib/listen/adapter/jruby.rb
@@ -14,17 +14,17 @@ module Listen
         java_import 'java.nio.file.Paths'
         java_import 'java.nio.file.StandardWatchEventKinds'
 
-        event_kinds = [
-          StandardWatchEventKinds::ENTRY_CREATE,
-          StandardWatchEventKinds::ENTRY_MODIFY,
-          StandardWatchEventKinds::ENTRY_DELETE
-        ]
+        @event_kind_map ||= {
+          StandardWatchEventKinds::ENTRY_CREATE => :added,
+          StandardWatchEventKinds::ENTRY_MODIFY => :modified,
+          StandardWatchEventKinds::ENTRY_DELETE => :removed
+        }
 
         @watcher ||= FileSystems.getDefault.newWatchService
         p @watcher.class.name
         @keys ||= {}
         path = Paths.get(directory.to_s)
-        key = path.register(@watcher, *event_kinds)
+        key = path.register(@watcher, *@event_kind_map.keys)
         @keys[key] = path
       end
 
@@ -38,9 +38,17 @@ module Listen
               next if kind == StandardWatchEventKinds::OVERFLOW
               name = event.context
               child = dir.resolve(name)
-p child.to_s
-              pathname = Pathname.new(child.to_s).dirname
-              _queue_change(:dir, pathname, '.', recursive: true)
+              dirname = Pathname.new(child.to_s).dirname
+              full_path = Pathname.new(child.to_s)
+              if full_path.directory?
+                p [:dir, dirname]
+                _queue_change(:dir, dirname, '.', recursive: true)
+              elsif full_path.exist?
+                path = full_path.relative_path_from(dirname)
+                changed = @event_kind_map[kind]
+                p [:file, dirname, path.to_s, changed: changed]
+                _queue_change(:file, dirname, path.to_s, changed: changed)
+              end
             end
           end
           valid = key.reset

--- a/lib/listen/adapter/jruby.rb
+++ b/lib/listen/adapter/jruby.rb
@@ -1,0 +1,55 @@
+module Listen
+  module Adapter
+    # @see https://docs.oracle.com/javase/tutorial/essential/io/notification.html
+    class Jruby < Base
+      def self.usable?
+        RUBY_ENGINE == 'jruby'
+      end
+
+      private
+
+      def _configure(directory, &_callback)
+        require 'java'
+        java_import 'java.nio.file.FileSystems'
+        java_import 'java.nio.file.Paths'
+        java_import 'java.nio.file.StandardWatchEventKinds'
+
+        event_kinds = [
+          StandardWatchEventKinds::ENTRY_CREATE,
+          StandardWatchEventKinds::ENTRY_MODIFY,
+          StandardWatchEventKinds::ENTRY_DELETE
+        ]
+
+        @watcher ||= FileSystems.getDefault.newWatchService
+        @keys ||= {}
+        path = Paths.get(directory.to_s)
+        key = path.register(@watcher, *event_kinds)
+        @keys[key] = path
+      end
+
+      def _run
+        loop do
+          key = @watcher.take
+          dir = @keys[key]
+          unless dir.nil?
+            key.pollEvents.each do |event|
+              kind = event.kind
+              next if kind == StandardWatchEventKinds::OVERFLOW
+              name = event.context
+              child = dir.resolve(name)
+              pathname = Pathname.new(child.to_s).dirname
+              _queue_change(:dir, pathname, '.', recursive: true)
+            end
+          end
+          valid = key.reset
+          unless valid
+            @keys.delete(key)
+            break if @keys.empty?
+          end
+        end
+      end
+
+      def _process_event(dir, event); end
+    end
+  end
+end

--- a/lib/listen/adapter/jruby.rb
+++ b/lib/listen/adapter/jruby.rb
@@ -38,6 +38,7 @@ module Listen
               next if kind == StandardWatchEventKinds::OVERFLOW
               name = event.context
               child = dir.resolve(name)
+p child.to_s
               pathname = Pathname.new(child.to_s).dirname
               _queue_change(:dir, pathname, '.', recursive: true)
             end

--- a/spec/lib/listen/adapter/jruby_spec.rb
+++ b/spec/lib/listen/adapter/jruby_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe Listen::Adapter::Jruby do
+  describe 'class' do
+    subject { described_class }
+
+    if jruby?
+      it { should be_usable }
+    else
+      it { should_not be_usable }
+    end
+  end
+end

--- a/spec/lib/listen/adapter_spec.rb
+++ b/spec/lib/listen/adapter_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Listen::Adapter do
     allow(Listen::Adapter::Darwin).to receive(:usable?) { false }
     allow(Listen::Adapter::Linux).to receive(:usable?) { false }
     allow(Listen::Adapter::Windows).to receive(:usable?) { false }
+    allow(Listen::Adapter::Jruby).to receive(:usable?) { false }
   end
 
   describe '.select' do
@@ -35,6 +36,12 @@ RSpec.describe Listen::Adapter do
       allow(Listen::Adapter::Windows).to receive(:usable?) { true }
       klass = Listen::Adapter.select
       expect(klass).to eq Listen::Adapter::Windows
+    end
+
+    it 'returns JRuby adapter when usable' do
+      allow(Listen::Adapter::Jruby).to receive(:usable?) { true }
+      klass = Listen::Adapter.select
+      expect(klass).to eq Listen::Adapter::Jruby
     end
 
     context 'no usable adapters' do

--- a/spec/support/platform_helper.rb
+++ b/spec/support/platform_helper.rb
@@ -13,3 +13,7 @@ end
 def windows?
   RbConfig::CONFIG['target_os'] =~ /mswin|mingw|cygwin/i
 end
+
+def jruby?
+  RUBY_ENGINE == 'jruby'
+end


### PR DESCRIPTION
This is a quick & hacky attempt at getting the basics of #462 working closely based on the [WatchDir example](https://docs.oracle.com/javase/tutorial/displayCode.html?code=https://docs.oracle.com/javase/tutorial/essential/io/examples/WatchDir.java) mentioned in the documentation.

I found that I had to bump `LISTEN_TESTS_DEFAULT_LAG` up when running the acceptance specs on my development machine (MacOS v10.13.6):

 ```
$ uname -a
Darwin trooz 17.7.0 Darwin Kernel Version 17.7.0: Sun Jun  2 20:31:42 PDT 2019; root:xnu-4570.71.46~1/RELEASE_X86_64 x86_64
$ ruby --version
jruby 9.2.7.0 (2.5.3) 2019-04-09 8a269e3 Java HotSpot(TM) 64-Bit Server VM 25.152-b16 on 1.8.0_152-b16 +jit [darwin-x86_64]
```

Although I didn't try to minimise the value of `LISTEN_TESTS_DEFAULT_LAG`, I was using ~5 seconds to get the acceptance specs to pass successfully. This doesn't seem very encouraging, but maybe I'm doing something wrong! I'm hoping that pushing this up will yield some better results from Travis CI.

### To-do (not exhaustive)

* [ ] Thread safety
* [ ] Recursive watching of sub-directories...?
* [ ] Cope with multiple directories
* [ ] Use `callback` passed into `#_configure` as intended...?
* [ ] Use `#_process_event` as intended...?
* [ ] Error handling...?
* [ ] Check that `Listen::Adapter::Jruby.usable?` implementation is sensible
* [ ] Update Travis CI config if necessary...?

/cc @headius @bratish
