### PR TITLE
Fix warnings in spec output

### DIFF
--- a/spec/lib/listen/adapter/darwin_spec.rb
+++ b/spec/lib/listen/adapter/darwin_spec.rb
@@ -89,10 +89,13 @@ RSpec.describe Adapter::Darwin do
       expectations.each do |dir, obj|
         allow(obj).to receive(:watch).with(dir.to_s, latency: 0.1)
       end
-      subject.configure
     end
 
     describe 'configuration' do
+      before do
+        subject.configure
+      end
+
       context 'with 1 directory' do
         let(:directories) { expectations.keys.map { |p| Pathname(p.to_s) } }
 

--- a/spec/lib/listen/event/loop_spec.rb
+++ b/spec/lib/listen/event/loop_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe Listen::Event::Loop do
     it 'sets up the thread in a resumable state' do
       subject.setup
 
-      expect(subject).to receive(:sleep).with(no_args).ordered
-      allow(processor).to receive(:loop_for).with(1.234).ordered
+      expect(subject).to receive(:sleep).with(no_args)
+      allow(processor).to receive(:loop_for).with(1.234)
 
       blocks[:thread_block].call
     end
@@ -91,8 +91,8 @@ RSpec.describe Listen::Event::Loop do
       subject.setup
 
       allow(thread).to receive(:wakeup) do
-        allow(subject).to receive(:sleep).with(no_args).ordered
-        allow(processor).to receive(:loop_for).with(1.234).ordered
+        allow(subject).to receive(:sleep).with(no_args)
+        allow(processor).to receive(:loop_for).with(1.234)
         allow(ready).to receive(:<<).with(:ready)
         blocks[:thread_block].call
       end
@@ -153,7 +153,7 @@ RSpec.describe Listen::Event::Loop do
 
       subject.setup
 
-      allow(subject).to receive(:sleep).with(no_args).ordered do
+      allow(subject).to receive(:sleep).with(no_args) do
         allow(processor).to receive(:loop_for).with(1.234)
         blocks[:timer_block].call
       end

--- a/spec/lib/listen/event/processor_spec.rb
+++ b/spec/lib/listen/event/processor_spec.rb
@@ -105,11 +105,11 @@ RSpec.describe Listen::Event::Processor do
             it 'sleeps for latency to possibly later optimize some events' do
               # pretend we were woken up at 0.6 seconds since start
               allow(config).to receive(:sleep).
-                with(no_args) { |*_args| state[:time] += 0.6 }.ordered
+                with(no_args) { |*_args| state[:time] += 0.6 }
 
               # pretend we slept for latency (now: 1.6 seconds since start)
               allow(config).to receive(:sleep).
-                with(1.0) { |*_args| state[:time] += 1.0 }.ordered
+                with(1.0) { |*_args| state[:time] += 1.0 }
 
               subject.loop_for(1)
             end
@@ -123,14 +123,14 @@ RSpec.describe Listen::Event::Processor do
             it 'still does not process events because it is paused' do
               # pretend we were woken up at 0.6 seconds since start
               allow(config).to receive(:sleep).
-                with(no_args) { |*_args| state[:time] += 2.0 }.ordered
+                with(no_args) { |*_args| state[:time] += 2.0 }
 
               # second loop starts here (no sleep, coz recent events, but no
               # processing coz paused
 
               # pretend we were woken up at 3.6 seconds since start
               allow(config).to receive(:sleep).
-                with(no_args) { |*_args| state[:time] += 3.0 }.ordered
+                with(no_args) { |*_args| state[:time] += 3.0 }
 
               subject.loop_for(1)
             end


### PR DESCRIPTION
This fixes two types of warnings which were appearing in the spec output thus reducing the signal-to-noise ratio.