### PR TITLE
Ignore mutagen sync temporary files

### DIFF
--- a/lib/listen/silencer.rb
+++ b/lib/listen/silencer.rb
@@ -46,6 +46,9 @@ module Listen
          )
         )
 
+      # Mutagen sync temporary files
+      | \.mutagen-temporary.*
+
       # other files
       | \.DS_Store
       | \.tmp

--- a/spec/lib/listen/silencer_spec.rb
+++ b/spec/lib/listen/silencer_spec.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 RSpec::Matchers.define :accept do |type, path|
   match { |actual| !actual.silenced?(Pathname(path), type) }
 end

--- a/spec/lib/listen/silencer_spec.rb
+++ b/spec/lib/listen/silencer_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 RSpec::Matchers.define :accept do |type, path|
   match { |actual| !actual.silenced?(Pathname(path), type) }
 end
@@ -34,6 +36,12 @@ RSpec.describe Listen::Silencer do
 
       # sed temp files
       ignored += %w(sedq7eVAR sed86w1kB)
+
+      # mutagen temp files
+      ignored += %w(
+        .mutagen-temporary-cross-device-rename0
+        .mutagen-temporary-unicode-test-éntry0
+      )
 
       ignored.each do |path|
         it { should_not accept(:file, path) }


### PR DESCRIPTION
[Mutagen](https://mutagen.io) is a sync tool for remote development that copies files into place on a remote machine [running listen/guard] when edits are made on a local machine. To perform an atomic update, it creates a temp/staging file and moves it into place.

Normally this results in an addition, which results in the change being ignored by many guard plugins. Listen's `QueueOptimizer` can [detect this][] as an "editor save" when it detects that a silenced temp file is moved to replace a watched file.

This patch updates the ignore pattern to detect mutagen temp files, silencing them and allowing the staging file move to be detected properly as a modification.

[detect this]: https://github.com/guard/listen/blob/2fe70d6226805410f6ba9790eb1acca4533bcb75/lib/listen/queue_optimizer.rb#L128

Post-merge tasks
---

- [ ] Update [Guardfile DSL wiki ignore section](https://github.com/guard/guard/wiki/Guardfile-DSL---Configuring-Guard#ignore) to include this new default