### PR TITLE
Include macOS Big Sur in Adapter::Darwin#usable?

### DIFF
--- a/lib/listen/adapter/darwin.rb
+++ b/lib/listen/adapter/darwin.rb
@@ -6,7 +6,7 @@ module Listen
     # Adapter implementation for Mac OS X `FSEvents`.
     #
     class Darwin < Base
-      OS_REGEXP = /darwin(?<major_version>1\d+)/i
+      OS_REGEXP = /darwin(?<major_version>(1|2)\d+)/i
 
       # The default delay between checking for changes.
       DEFAULTS = { latency: 0.1 }.freeze

--- a/spec/lib/listen/adapter/darwin_spec.rb
+++ b/spec/lib/listen/adapter/darwin_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe Adapter::Darwin do
       it { should be_usable }
     end
 
+    context 'on darwin20 (macOS Big Sur)' do
+      before do
+        allow(RbConfig::CONFIG).to receive(:[]).and_return('darwin20')
+      end
+
+      it { should be_usable }
+    end
+
     context 'on darwin10.0 (OS X Snow Leopard)' do
       before do
         allow(RbConfig::CONFIG).to receive(:[]).and_return('darwin10.0')


### PR DESCRIPTION
macOS Big Sur has target_os=darwin20

Darwin-adapter only looks for versions in [10,19]

Changed Darwin-adapter-regex to look for version numbers in [10,29]

Work on #478 