### PR TITLE
Issue #481 fix hanging race condition

### DIFF
--- a/lib/listen/adapter/base.rb
+++ b/lib/listen/adapter/base.rb
@@ -87,10 +87,7 @@ module Listen
 
       def stop
         _stop
-      end
-
-      def self.usable?
-        const_get('OS_REGEXP') =~ RbConfig::CONFIG['target_os']
+        config.queue.close # this causes queue.pop to return `nil` to the front-end
       end
 
       private
@@ -133,6 +130,10 @@ module Listen
       end
 
       class << self
+        def usable?
+          const_get('OS_REGEXP') =~ RbConfig::CONFIG['target_os']
+        end
+
         private
 
         def _log(*args, &block)

--- a/lib/listen/event/config.rb
+++ b/lib/listen/event/config.rb
@@ -19,8 +19,8 @@ module Listen
         @block = block
       end
 
-      def sleep(*args)
-        Kernel.sleep(*args)
+      def sleep(seconds)
+        Kernel.sleep(seconds)
       end
 
       def call(*args)

--- a/lib/listen/event/config.rb
+++ b/lib/listen/event/config.rb
@@ -1,6 +1,10 @@
 module Listen
   module Event
     class Config
+      attr_reader :listener
+      attr_reader :event_queue
+      attr_reader :min_delay_between_events
+
       def initialize(
         listener,
         event_queue,
@@ -27,8 +31,6 @@ module Listen
         Time.now.to_f
       end
 
-      attr_reader :event_queue
-
       def callable?
         @block
       end
@@ -36,20 +38,6 @@ module Listen
       def optimize_changes(changes)
         @queue_optimizer.smoosh_changes(changes)
       end
-
-      attr_reader :min_delay_between_events
-
-      def stopped?
-        listener.state == :stopped
-      end
-
-      def paused?
-        listener.state == :paused
-      end
-
-      private
-
-      attr_reader :listener
     end
   end
 end

--- a/lib/listen/event/loop.rb
+++ b/lib/listen/event/loop.rb
@@ -60,7 +60,7 @@ module Listen
         # fail NotImplementedError
       end
 
-      def teardown
+      def stop
         return if stopped?
         transition! :stopped
 

--- a/lib/listen/event/loop.rb
+++ b/lib/listen/event/loop.rb
@@ -23,7 +23,7 @@ module Listen
         @config = config
         @wait_thread = nil
         @reasons = ::Queue.new
-        super()
+        initialize_fsm
       end
 
       def wakeup_on_event

--- a/lib/listen/event/loop.rb
+++ b/lib/listen/event/loop.rb
@@ -59,7 +59,6 @@ module Listen
         _transition!(:stopped)
 
         if @wait_thread.alive?
-          _wakeup(:teardown)
           @wait_thread.join.kill
         end
         @wait_thread = nil

--- a/lib/listen/event/loop.rb
+++ b/lib/listen/event/loop.rb
@@ -33,7 +33,7 @@ module Listen
         @state = :starting
         q = ::Queue.new
         @wait_thread = Thread.new do
-          _wait_for_changes(q)
+          _process_changes(q)
         end
 
         Listen::Logger.debug('Waiting for processing to start...')
@@ -67,11 +67,12 @@ module Listen
 
       private
 
-      def _wait_for_changes(ready_queue)
+      def _process_changes(ready_queue)
         processor = Event::Processor.new(@config, @reasons)
 
         _wait_until_resumed(ready_queue)
         processor.loop_for(@config.min_delay_between_events)
+
       rescue StandardError => ex
         _nice_error(ex)
       end

--- a/lib/listen/event/processor.rb
+++ b/lib/listen/event/processor.rb
@@ -40,7 +40,7 @@ module Listen
 
           # give events a bit of time to accumulate so they can be
           # compressed/optimized
-          _sleep(:waiting_until_latency, diff)
+          _sleep(diff)
         end
       end
 
@@ -55,9 +55,9 @@ module Listen
         raise Stopped
       end
 
-      def _sleep(_local_reason, *args)
+      def _sleep(seconds)
         _check_stopped
-        sleep_duration = config.sleep(*args)
+        config.sleep(seconds)
         _check_stopped
 
         _flush_wakeup_reasons do |reason|
@@ -65,8 +65,6 @@ module Listen
             _remember_time_of_first_unprocessed_event
           end
         end
-
-        sleep_duration
       end
 
       def _remember_time_of_first_unprocessed_event

--- a/lib/listen/event/processor.rb
+++ b/lib/listen/event/processor.rb
@@ -3,6 +3,7 @@ module Listen
     class Processor
       def initialize(config, reasons)
         @config = config
+        @listener = config.listener
         @reasons = reasons
         _reset_no_unprocessed_events
       end
@@ -45,11 +46,11 @@ module Listen
 
       def _wait_until_no_longer_paused
         # TODO: may not be a good idea?
-        _sleep(:waiting_for_unpause) while config.paused?
+        _sleep(:waiting_for_unpause) while @listener.paused?
       end
 
       def _check_stopped
-        return unless config.stopped?
+        return unless @listener.stopped?
 
         _flush_wakeup_reasons
         raise Stopped
@@ -61,7 +62,7 @@ module Listen
         _check_stopped
 
         _flush_wakeup_reasons do |reason|
-          if reason == :event && !config.paused?
+          if reason == :event && !@listener.paused?
             _remember_time_of_first_unprocessed_event
           end
         end

--- a/lib/listen/event/processor.rb
+++ b/lib/listen/event/processor.rb
@@ -45,8 +45,7 @@ module Listen
       end
 
       def _wait_until_no_longer_paused
-        # TODO: may not be a good idea?
-        _sleep(:waiting_for_unpause) while @listener.paused?
+        @listener.wait_for_state(:processing_events, :stopped)
       end
 
       def _check_stopped

--- a/lib/listen/event/processor.rb
+++ b/lib/listen/event/processor.rb
@@ -45,7 +45,7 @@ module Listen
       end
 
       def _wait_until_no_longer_paused
-        @listener.wait_for_state(:processing_events, :stopped)
+        @listener.wait_for_state(*(Listener.states.keys - [:paused]))
       end
 
       def _check_stopped

--- a/lib/listen/event/queue.rb
+++ b/lib/listen/event/queue.rb
@@ -18,8 +18,8 @@ module Listen
       end
 
       def initialize(config, &block)
+        block and raise ArgumentError, "&block no longer needed"
         @event_queue = ::Queue.new
-        @block = block
         @config = config
       end
 
@@ -31,17 +31,15 @@ module Listen
 
         dir = _safe_relative_from_cwd(dir)
         event_queue.public_send(:<<, [type, change, dir, path, options])
-
-        block.call(args) if block
       end
 
       delegate empty?: :event_queue
       delegate pop: :event_queue
+      delegate close: :event_queue
 
       private
 
       attr_reader :event_queue
-      attr_reader :block
       attr_reader :config
 
       def _safe_relative_from_cwd(dir)

--- a/lib/listen/event/queue.rb
+++ b/lib/listen/event/queue.rb
@@ -17,8 +17,7 @@ module Listen
         end
       end
 
-      def initialize(config, &block)
-        block and raise ArgumentError, "&block no longer needed"
+      def initialize(config)
         @event_queue = ::Queue.new
         @config = config
       end

--- a/lib/listen/fsm.rb
+++ b/lib/listen/fsm.rb
@@ -68,12 +68,12 @@ module Listen
     # checks for one of the given states
     # if not already, waits for a state change (up to timeout seconds--`nil` means infinite)
     # returns truthy iff the transition to one of the desired state has occurred
-    def wait_for_state(*states, timeout: nil)
+    def wait_for_state(*wait_for_states, timeout: nil)
       @mutex.synchronize do
-        if !states.include?(@state)
+        if !wait_for_states.include?(@state)
           @state_changed.wait(@mutex, timeout)
         end
-        states.include?(@state)
+        wait_for_states.include?(@state)
       end
     end
 

--- a/lib/listen/fsm.rb
+++ b/lib/listen/fsm.rb
@@ -62,7 +62,7 @@ module Listen
       @mutex.synchronize do
         yield if block_given?
         @state = new_state_name
-        @state_changed.signal
+        @state_changed.broadcast
       end
     end
 

--- a/lib/listen/fsm.rb
+++ b/lib/listen/fsm.rb
@@ -37,12 +37,12 @@ module Listen
       end
     end
 
-    # Note: you must call super() from including classes so this code will run
-    def initialize
+    # Note: including classes must call initialize_fsm from their initialize method.
+    def initialize_fsm
+      @fsm_initialized = true
       @state = self.class.start_state
       @mutex = ::Mutex.new
       @state_changed = ::ConditionVariable.new
-      super
     end
 
     # Current state of the FSM, stored as a symbol
@@ -58,7 +58,7 @@ module Listen
     # Low-level, immediate state transition with no checks or callbacks.
     def transition!(new_state_name)
       new_state_name.is_a?(Symbol) or raise ArgumentError, "state name must be a Symbol (got #{new_state_name.inspect})"
-      @mutex or raise ArgumentError, "FSM not initialized. You must call super() from initialize!"
+      @fsm_initialized or raise ArgumentError, "FSM not initialized. You must call initialize_fsm from initialize!"
       @mutex.synchronize do
         yield if block_given?
         @state = new_state_name

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -57,7 +57,7 @@ module Listen
 
       @processor = Event::Loop.new(pconfig)
 
-      super() # FSM
+      initialize_fsm
     end
 
     start_state :initializing
@@ -65,20 +65,20 @@ module Listen
     state :initializing, to: [:backend_started, :stopped]
 
     state :backend_started, to: [:processing_events, :stopped] do
-      backend.start
+      @backend.start
     end
 
     state :processing_events, to: [:paused, :stopped] do
-      processor.start
+      @processor.start
     end
 
     state :paused, to: [:processing_events, :stopped] do
-      processor.pause
+      @processor.pause
     end
 
     state :stopped, to: [:backend_started] do
-      backend.stop # should be before processor.stop to halt events ASAP
-      processor.stop
+      @backend.stop # halt events ASAP
+      @processor.stop
     end
 
     # Starts processing events and starts adapters
@@ -129,10 +129,5 @@ module Listen
     def only(regexps)
       @silencer_controller.replace_with_only(regexps)
     end
-
-    private
-
-    attr_reader :processor
-    attr_reader :backend
   end
 end

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -19,7 +19,6 @@ require 'listen/listener/config'
 
 module Listen
   class Listener
-    # TODO: move the state machine's methods private
     include Listen::FSM
 
     # Initializes the directories listener.

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -73,7 +73,7 @@ module Listen
     end
 
     state :processing_events, to: [:paused, :stopped] do
-      processor.resume
+      # nothing to do--already started
     end
 
     state :paused, to: [:processing_events, :stopped] do

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -38,7 +38,7 @@ module Listen
       @config = Config.new(options)
 
       eq_config = Event::Queue::Config.new(@config.relative?)
-      queue = Event::Queue.new(eq_config) { @processor.wakeup_on_event }
+      queue = Event::Queue.new(eq_config)
 
       silencer = Silencer.new
       rules = @config.silencer_rules

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -60,7 +60,7 @@ module Listen
       super() # FSM
     end
 
-    default_state :initializing
+    start_state :initializing
 
     state :initializing, to: [:backend_started, :stopped]
 

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -69,7 +69,7 @@ module Listen
     end
 
     state :frontend_ready, to: [:processing_events, :stopped] do
-      processor.setup
+      processor.start
     end
 
     state :processing_events, to: [:paused, :stopped] do

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -77,8 +77,8 @@ module Listen
     end
 
     state :stopped, to: [:backend_started] do
-      backend.stop # should be before processor.teardown to halt events ASAP
-      processor.teardown
+      backend.stop # should be before processor.stop to halt events ASAP
+      processor.stop
     end
 
     # Starts processing events and starts adapters

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -114,6 +114,10 @@ module Listen
       state == :paused
     end
 
+    def stopped?
+      state == :stopped
+    end
+
     def ignore(regexps)
       @silencer_controller.append_ignores(regexps)
     end

--- a/listen.gemspec
+++ b/listen.gemspec
@@ -1,5 +1,5 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'listen/version'
 

--- a/spec/lib/listen/adapter/linux_spec.rb
+++ b/spec/lib/listen/adapter/linux_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe Listen::Adapter::Linux do
   end
 
   if linux?
-    let(:dir1) {Pathname.new("/foo/dir1")}
+    let(:dir1) { Pathname.new("/foo/dir1") }
 
-    let(:config) { instance_double(Listen::Adapter::Config) }
-    let(:queue) { instance_double(Queue) }
-    let(:silencer) { instance_double(Listen::Silencer) }
-    let(:snapshot) { instance_double(Listen::Change) }
-    let(:record) { instance_double(Listen::Record) }
+    let(:config) { instance_double(Listen::Adapter::Config, "config") }
+    let(:queue) { instance_double(Queue, "queue") }
+    let(:silencer) { instance_double(Listen::Silencer, "silencer") }
+    let(:snapshot) { instance_double(Listen::Change, "snapshot") }
+    let(:record) { instance_double(Listen::Record, "record") }
 
     # TODO: fix other adapters too!
     subject { described_class.new(config) }
@@ -134,6 +134,7 @@ RSpec.describe Listen::Adapter::Linux do
           stub_const('INotify::Notifier', fake_notifier)
 
           allow(config).to receive(:queue).and_return(queue)
+          allow(queue).to receive(:close)
           allow(config).to receive(:silencer).and_return(silencer)
 
           allow(subject).to receive(:require).with('rb-inotify')
@@ -147,6 +148,11 @@ RSpec.describe Listen::Adapter::Linux do
       end
 
       context 'when not even initialized' do
+        before do
+          allow(config).to receive(:queue).and_return(queue)
+          allow(queue).to receive(:close)
+        end
+
         it 'does not crash' do
           expect do
             subject.stop

--- a/spec/lib/listen/adapter/polling_spec.rb
+++ b/spec/lib/listen/adapter/polling_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe Adapter::Polling do
   # just so cleanpath works in above double
   let(:real_dir1) { instance_double(Pathname, 'dir1', to_s: '/foo/dir1') }
 
-  let(:config) { instance_double(Listen::Adapter::Config) }
+  let(:config) { instance_double(Listen::Adapter::Config, "config") }
   let(:directories) { [dir1] }
   let(:options) { {} }
-  let(:queue) { instance_double(Queue) }
-  let(:silencer) { instance_double(Listen::Silencer) }
-  let(:snapshot) { instance_double(Listen::Change) }
+  let(:queue) { instance_double(Queue, "queue") }
+  let(:silencer) { instance_double(Listen::Silencer, "silencer") }
+  let(:snapshot) { instance_double(Listen::Change, "snapshot") }
 
   let(:record) { instance_double(Listen::Record) }
 
@@ -48,6 +48,7 @@ RSpec.describe Adapter::Polling do
       end
 
       after do
+        allow(queue).to receive(:close)
         subject.stop
       end
 

--- a/spec/lib/listen/event/loop_spec.rb
+++ b/spec/lib/listen/event/loop_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Listen::Event::Loop do
   let(:blocks) do
     {
       thread_block: proc { fail 'thread block stub called' },
-      timer_block: proc { fail 'thread block stub called' }
     }
   end
 
@@ -37,10 +36,6 @@ RSpec.describe Listen::Event::Loop do
       thread
     end
 
-    allow(Timeout).to receive(:timeout) do |*_args, &block|
-      blocks[:timer_block] = block
-    end
-
     allow(Kernel).to receive(:sleep) do |*args|
       fail "stub called: sleep(#{args.map(&:inspect) * ','})"
     end
@@ -52,32 +47,7 @@ RSpec.describe Listen::Event::Loop do
     end
   end
 
-  describe '#setup' do
-    before do
-      allow(thread).to receive(:wakeup)
-      allow(thread).to receive(:alive?).and_return(true)
-      allow(config).to receive(:min_delay_between_events).and_return(1.234)
-      allow(ready).to receive(:<<).with(:ready)
-    end
-
-    it 'sets up the thread in a resumable state' do
-      subject.start
-
-      expect(subject).to receive(:sleep).with(no_args)
-      allow(processor).to receive(:loop_for).with(1.234)
-
-      blocks[:thread_block].call
-    end
-  end
-
   context 'when stopped' do
-    context 'when resume is called' do
-      it 'fails' do
-        expect { subject.resume }.
-          to raise_error(Listen::Event::Loop::Error::NotStarted)
-      end
-    end
-
     context 'when wakeup_on_event is called' do
       it 'does nothing' do
         subject.wakeup_on_event
@@ -85,28 +55,25 @@ RSpec.describe Listen::Event::Loop do
     end
   end
 
-  context 'when resumed' do
+  describe '#start' do
     before do
-      subject.start
-
-      allow(thread).to receive(:wakeup) do
-        allow(subject).to receive(:sleep).with(no_args)
-        allow(processor).to receive(:loop_for).with(1.234)
-        allow(ready).to receive(:<<).with(:ready)
-        blocks[:thread_block].call
+      expect(Listen::Internals::ThreadPool).to receive(:add) do |*_, &block|
+        block.call
+        thread
       end
 
-      allow(reasons).to receive(:<<).with(:resume)
-      subject.resume
+      expect(processor).to receive(:loop_for).with(1.234)
+
+      subject.start
     end
 
     it 'is started' do
       expect(subject).to be_started
     end
 
-    context 'when resume is called again' do
-      it 'does nothing' do
-        subject.resume
+    context 'when start is called again' do
+      it 'raises AlreadyStarted' do
+        expect { subject.start }.to raise_exception(Listen::Event::Loop::Error::AlreadyStarted)
       end
     end
 
@@ -121,10 +88,12 @@ RSpec.describe Listen::Event::Loop do
 
         it 'wakes up the thread' do
           expect(thread).to receive(:wakeup)
+          expect(subject.instance_variable_get(:@state)).to eq(:started)
           subject.wakeup_on_event
         end
 
         it 'sets the reason for waking up' do
+          expect(thread).to receive(:wakeup)
           expect(reasons).to receive(:<<).with(:event)
           subject.wakeup_on_event
         end
@@ -143,47 +112,26 @@ RSpec.describe Listen::Event::Loop do
     end
   end
 
-  context 'when set up / paused' do
+  context 'when set up / started' do
     before do
       allow(thread).to receive(:alive?).and_return(true)
       allow(config).to receive(:min_delay_between_events).and_return(1.234)
 
-      allow(thread).to receive(:wakeup)
+      allow(processor).to receive(:loop_for).with(1.234)
+
+      expect(Listen::Internals::ThreadPool).to receive(:add) do |*_, &block|
+        block.call
+        thread
+      end
 
       subject.start
-
-      allow(subject).to receive(:sleep).with(no_args) do
-        allow(processor).to receive(:loop_for).with(1.234)
-        blocks[:timer_block].call
-      end
-
-      allow(ready).to receive(:<<).with(:ready)
-      allow(ready).to receive(:pop)
-
-      blocks[:thread_block].call
-    end
-
-    describe '#resume' do
-      before do
-        allow(reasons).to receive(:<<)
-        allow(thread).to receive(:wakeup)
-      end
-
-      it 'resumes the thread' do
-        expect(thread).to receive(:wakeup)
-        subject.resume
-      end
-
-      it 'sets the reason for waking up' do
-        expect(reasons).to receive(:<<).with(:resume)
-        subject.resume
-      end
     end
 
     describe '#teardown' do
       before do
         allow(reasons).to receive(:<<)
         allow(thread).to receive_message_chain(:join, :kill)
+        expect(thread).to receive(:wakeup)
       end
 
       it 'frees the thread' do

--- a/spec/lib/listen/event/loop_spec.rb
+++ b/spec/lib/listen/event/loop_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Listen::Event::Loop do
     end
 
     it 'sets up the thread in a resumable state' do
-      subject.setup
+      subject.start
 
       expect(subject).to receive(:sleep).with(no_args)
       allow(processor).to receive(:loop_for).with(1.234)
@@ -87,7 +87,7 @@ RSpec.describe Listen::Event::Loop do
 
   context 'when resumed' do
     before do
-      subject.setup
+      subject.start
 
       allow(thread).to receive(:wakeup) do
         allow(subject).to receive(:sleep).with(no_args)
@@ -100,8 +100,8 @@ RSpec.describe Listen::Event::Loop do
       subject.resume
     end
 
-    it 'is not paused' do
-      expect(subject).to_not be_paused
+    it 'is started' do
+      expect(subject).to be_started
     end
 
     context 'when resume is called again' do
@@ -150,7 +150,7 @@ RSpec.describe Listen::Event::Loop do
 
       allow(thread).to receive(:wakeup)
 
-      subject.setup
+      subject.start
 
       allow(subject).to receive(:sleep).with(no_args) do
         allow(processor).to receive(:loop_for).with(1.234)

--- a/spec/lib/listen/event/loop_spec.rb
+++ b/spec/lib/listen/event/loop_spec.rb
@@ -127,22 +127,22 @@ RSpec.describe Listen::Event::Loop do
       subject.start
     end
 
-    describe '#teardown' do
+    describe '#stop' do
       before do
         allow(thread).to receive_message_chain(:join, :kill)
       end
 
       it 'frees the thread' do
-        subject.teardown
+        subject.stop
       end
 
       it 'waits for the thread to finish' do
         expect(thread).to receive_message_chain(:join, :kill)
-        subject.teardown
+        subject.stop
       end
 
       it 'sets the reason for waking up' do
-        subject.teardown
+        subject.stop
       end
     end
   end

--- a/spec/lib/listen/event/loop_spec.rb
+++ b/spec/lib/listen/event/loop_spec.rb
@@ -64,8 +64,8 @@ RSpec.describe Listen::Event::Loop do
     end
 
     context 'when start is called again' do
-      it 'raises AlreadyStarted' do
-        expect { subject.start }.to raise_exception(Listen::Event::Loop::Error::AlreadyStarted)
+      it 'returns silently' do
+        expect { subject.start }.to_not raise_exception
       end
     end
   end

--- a/spec/lib/listen/event/loop_spec.rb
+++ b/spec/lib/listen/event/loop_spec.rb
@@ -129,9 +129,7 @@ RSpec.describe Listen::Event::Loop do
 
     describe '#teardown' do
       before do
-        allow(reasons).to receive(:<<)
         allow(thread).to receive_message_chain(:join, :kill)
-        expect(thread).to receive(:wakeup)
       end
 
       it 'frees the thread' do
@@ -144,7 +142,6 @@ RSpec.describe Listen::Event::Loop do
       end
 
       it 'sets the reason for waking up' do
-        expect(reasons).to receive(:<<).with(:teardown)
         subject.teardown
       end
     end

--- a/spec/lib/listen/event/loop_spec.rb
+++ b/spec/lib/listen/event/loop_spec.rb
@@ -47,14 +47,6 @@ RSpec.describe Listen::Event::Loop do
     end
   end
 
-  context 'when stopped' do
-    context 'when wakeup_on_event is called' do
-      it 'does nothing' do
-        subject.wakeup_on_event
-      end
-    end
-  end
-
   describe '#start' do
     before do
       expect(Listen::Internals::ThreadPool).to receive(:add) do |*_, &block|

--- a/spec/lib/listen/event/loop_spec.rb
+++ b/spec/lib/listen/event/loop_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Listen::Event::Loop do
 
   describe '#start' do
     before do
-      expect(Listen::Internals::ThreadPool).to receive(:add) do |*_, &block|
+      expect(Thread).to receive(:new) do |&block|
         block.call
         thread
       end
@@ -68,40 +68,6 @@ RSpec.describe Listen::Event::Loop do
         expect { subject.start }.to raise_exception(Listen::Event::Loop::Error::AlreadyStarted)
       end
     end
-
-    context 'when wakeup_on_event is called' do
-      let(:epoch) { 1234 }
-
-      context 'when thread is alive' do
-        before do
-          allow(reasons).to receive(:<<)
-          allow(thread).to receive(:alive?).and_return(true)
-        end
-
-        it 'wakes up the thread' do
-          expect(thread).to receive(:wakeup)
-          expect(subject.instance_variable_get(:@state)).to eq(:started)
-          subject.wakeup_on_event
-        end
-
-        it 'sets the reason for waking up' do
-          expect(thread).to receive(:wakeup)
-          expect(reasons).to receive(:<<).with(:event)
-          subject.wakeup_on_event
-        end
-      end
-
-      context 'when thread is dead' do
-        before do
-          allow(thread).to receive(:alive?).and_return(false)
-        end
-
-        it 'does not wake up the thread' do
-          expect(thread).to_not receive(:wakeup)
-          subject.wakeup_on_event
-        end
-      end
-    end
   end
 
   context 'when set up / started' do
@@ -111,7 +77,7 @@ RSpec.describe Listen::Event::Loop do
 
       allow(processor).to receive(:loop_for).with(1.234)
 
-      expect(Listen::Internals::ThreadPool).to receive(:add) do |*_, &block|
+      expect(Thread).to receive(:new) do |&block|
         block.call
         thread
       end

--- a/spec/lib/listen/event/processor_spec.rb
+++ b/spec/lib/listen/event/processor_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Listen::Event::Processor do
             it 'sleeps for latency to possibly later optimize some events' do
               # pretend we were woken up at 0.6 seconds since start
               allow(config).to receive(:sleep).
-                with(no_args) { |*_args| state[:time] += 0.6 }
+                with(anything) { |*_args| state[:time] += 0.6 }
 
               # pretend we slept for latency (now: 1.6 seconds since start)
               allow(config).to receive(:sleep).
@@ -130,7 +130,7 @@ RSpec.describe Listen::Event::Processor do
             it 'still does not process events because it is paused' do
               # pretend we were woken up at 0.6 seconds since start
               allow(config).to receive(:sleep).
-                with(1) { |*_args| state[:time] += 2.0 }
+                with(anything) { |*_args| state[:time] += 2.0 }
 
               # second loop starts here (no sleep, coz recent events, but no
               # processing coz paused

--- a/spec/lib/listen/event/processor_spec.rb
+++ b/spec/lib/listen/event/processor_spec.rb
@@ -4,7 +4,8 @@ require 'listen/event/config'
 RSpec.describe Listen::Event::Processor do
   let(:event_queue) { instance_double(::Queue, 'event_queue') }
   let(:event) { instance_double(::Array, 'event') }
-  let(:config) { instance_double(Listen::Event::Config) }
+  let(:listener) { instance_double(Listen::Listener, 'listener') }
+  let(:config) { instance_double(Listen::Event::Config, listener: listener) }
   let(:reasons) { instance_double(::Queue, 'reasons') }
 
   subject { described_class.new(config, reasons) }
@@ -28,11 +29,11 @@ RSpec.describe Listen::Event::Processor do
   before do
     allow(config).to receive(:event_queue).and_return(event_queue)
 
-    allow(config).to receive(:stopped?) do
+    allow(listener).to receive(:stopped?) do
       status_for_time(state[:time]) == :stopped
     end
 
-    allow(config).to receive(:paused?) do
+    allow(listener).to receive(:paused?) do
       status_for_time(state[:time]) == :paused
     end
 

--- a/spec/lib/listen/event/processor_spec.rb
+++ b/spec/lib/listen/event/processor_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Listen::Event::Processor do
 
               # pretend we were woken up at 3.6 seconds since start
               allow(listener).to receive(:wait_for_state).
-                with(:processing_events, :stopped) do |*_args|
+                with(:initializing, :backend_started, :processing_events, :stopped) do |*_args|
                   state[:time] += 3.0
                   raise ScriptError, 'done'
                 end
@@ -210,7 +210,7 @@ RSpec.describe Listen::Event::Processor do
               end
 
               allow(listener).to receive(:wait_for_state).
-                with(:processing_events, :stopped)
+                with(:initializing, :backend_started, :processing_events, :stopped)
 
               subject.instance_variable_set(:@first_unprocessed_event_time, -3)
               subject.loop_for(1)

--- a/spec/lib/listen/event/queue_spec.rb
+++ b/spec/lib/listen/event/queue_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe Listen::Event::Queue do
 
   let(:relative) { false }
 
-  let(:block) { proc {} }
-
-  subject { described_class.new(config, &block) }
+  subject { described_class.new(config) }
 
   before do
     allow(config).to receive(:relative?).and_return(relative)
@@ -54,26 +52,6 @@ RSpec.describe Listen::Event::Queue do
     let(:watched_dir) { fake_path('watched_dir') }
     before do
       allow(queue).to receive(:<<)
-    end
-
-    context 'when a block is given' do
-      let(:calls) { [] }
-      let(:block) { proc { calls << 'called!' } }
-
-      it 'calls the provided block' do
-        subject.<<([:file, :modified, watched_dir, 'foo', {}])
-        expect(calls).to eq(['called!'])
-      end
-    end
-
-    context 'when no block is given' do
-      let(:calls) { [] }
-      let(:block) { nil }
-
-      it 'calls the provided block' do
-        subject.<<([:file, :modified, watched_dir, 'foo', {}])
-        expect(calls).to eq([])
-      end
     end
 
     context 'when relative option is true' do

--- a/spec/lib/listen/fsm_spec.rb
+++ b/spec/lib/listen/fsm_spec.rb
@@ -1,0 +1,103 @@
+RSpec.describe Listen::FSM do
+  context "simple FSM" do
+    class SpecSimpleFsm
+      include Listen::FSM
+
+      attr_reader :entered_started
+
+      start_state :initial
+
+      state :started, to: :stopped do
+        @entered_started = true
+      end
+
+      state :failed, to: :stopped
+
+      state :stopped
+
+      def start
+        transition(:started)
+      end
+
+      def stop
+        transition(:stopped)
+      end
+
+      def fail
+        transition(:failed)
+      end
+
+      def initialize
+        initialize_fsm
+      end
+    end
+
+    subject(:fsm) { SpecSimpleFsm.new }
+
+    it "starts in start_state" do
+      expect(subject.state).to eq(:initial)
+    end
+
+    it "allows transitions" do
+      subject.start
+      expect(subject.state).to eq(:started)
+      expect(subject.entered_started).to eq(true)
+    end
+
+    it "raises on disallowed transitions" do
+      subject.fail
+      expect { subject.start }.to raise_exception(ArgumentError, "SpecSimpleFsm can't change state from 'failed' to 'started', only to: stopped")
+      expect(subject.state).to eq(:failed)
+      expect(subject.entered_started).to eq(nil)
+    end
+
+    it "declares transition and transition! private" do
+      expect { subject.transition(:started) }.to raise_exception(NoMethodError, /private.*transition/)
+      expect { subject.transition!(:started) }.to raise_exception(NoMethodError, /private.*transition!/)
+    end
+  end
+
+  context "FSM with no start state" do
+    class SpecFsmWithNoStartState
+      include Listen::FSM
+
+      state :started, to: :stopped
+
+      state :failed, to: :stopped
+
+      state :stopped
+
+      def initialize
+        initialize_fsm
+      end
+    end
+
+    subject(:fsm) { SpecFsmWithNoStartState.new }
+
+    it "raises ArgumentError on new" do
+      expect { subject }.to raise_exception(ArgumentError, /`start_state :<state>` must be declared before `new`/)
+    end
+  end
+
+  context "FSM with string states" do
+    subject(:fsm) do
+      instance_exec do
+        class SpecFsmWithStringState
+          include Listen::FSM
+
+          state "started", to: "stopped"
+
+          state "stopped"
+
+          def initialize
+            initialize_fsm
+          end
+        end
+      end
+    end
+
+    it "raises ArgumentError on new" do
+      expect { subject }.to raise_exception(ArgumentError, /state name must be a Symbol/)
+    end
+  end
+end

--- a/spec/lib/listen/fsm_spec.rb
+++ b/spec/lib/listen/fsm_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Listen::FSM do
-  context "simple FSM" do
+  context 'simple FSM' do
     class SpecSimpleFsm
       include Listen::FSM
 
@@ -34,30 +34,33 @@ RSpec.describe Listen::FSM do
 
     subject(:fsm) { SpecSimpleFsm.new }
 
-    it "starts in start_state" do
+    it 'starts in start_state' do
       expect(subject.state).to eq(:initial)
     end
 
-    it "allows transitions" do
+    it 'allows transitions' do
       subject.start
       expect(subject.state).to eq(:started)
       expect(subject.entered_started).to eq(true)
     end
 
-    it "raises on disallowed transitions" do
+    it 'raises on disallowed transitions' do
       subject.fail
-      expect { subject.start }.to raise_exception(ArgumentError, "SpecSimpleFsm can't change state from 'failed' to 'started', only to: stopped")
+      expect do
+        subject.start
+      end.to raise_exception(ArgumentError,
+                             "SpecSimpleFsm can't change state from 'failed' to 'started', only to: stopped")
       expect(subject.state).to eq(:failed)
       expect(subject.entered_started).to eq(nil)
     end
 
-    it "declares transition and transition! private" do
+    it 'declares transition and transition! private' do
       expect { subject.transition(:started) }.to raise_exception(NoMethodError, /private.*transition/)
       expect { subject.transition!(:started) }.to raise_exception(NoMethodError, /private.*transition!/)
     end
   end
 
-  context "FSM with no start state" do
+  context 'FSM with no start state' do
     class SpecFsmWithNoStartState
       include Listen::FSM
 
@@ -74,20 +77,21 @@ RSpec.describe Listen::FSM do
 
     subject(:fsm) { SpecFsmWithNoStartState.new }
 
-    it "raises ArgumentError on new" do
-      expect { subject }.to raise_exception(ArgumentError, /`start_state :<state>` must be declared before `new`/)
+    it 'raises ArgumentError on new' do
+      expect { subject }.to raise_exception(ArgumentError,
+                                            /`start_state :<state>` must be declared before `new`/)
     end
   end
 
-  context "FSM with string states" do
+  context 'FSM with string state name' do
     subject(:fsm) do
       instance_exec do
         class SpecFsmWithStringState
           include Listen::FSM
 
-          state "started", to: "stopped"
+          state 'started', to: 'stopped'
 
-          state "stopped"
+          state 'stopped'
 
           def initialize
             initialize_fsm
@@ -96,7 +100,7 @@ RSpec.describe Listen::FSM do
       end
     end
 
-    it "raises ArgumentError on new" do
+    it 'raises ArgumentError on new' do
       expect { subject }.to raise_exception(ArgumentError, /state name must be a Symbol/)
     end
   end

--- a/spec/lib/listen/listener_spec.rb
+++ b/spec/lib/listen/listener_spec.rb
@@ -146,7 +146,6 @@ RSpec.describe Listener do
 
       it 'terminates' do
         allow(backend).to receive(:stop)
-        allow(processor).to receive(:teardown)
         subject.stop
       end
     end
@@ -158,7 +157,6 @@ RSpec.describe Listener do
 
       it 'terminates' do
         allow(backend).to receive(:stop)
-        allow(processor).to receive(:teardown)
         subject.stop
       end
     end

--- a/spec/lib/listen/listener_spec.rb
+++ b/spec/lib/listen/listener_spec.rb
@@ -146,6 +146,7 @@ RSpec.describe Listener do
 
       it 'terminates' do
         allow(backend).to receive(:stop)
+        allow(processor).to receive(:teardown)
         subject.stop
       end
     end
@@ -157,6 +158,7 @@ RSpec.describe Listener do
 
       it 'terminates' do
         allow(backend).to receive(:stop)
+        allow(processor).to receive(:teardown)
         subject.stop
       end
     end

--- a/spec/lib/listen/listener_spec.rb
+++ b/spec/lib/listen/listener_spec.rb
@@ -121,16 +121,14 @@ RSpec.describe Listener do
     end
 
     it 'sets paused to false' do
-      allow(processor).to receive(:setup)
-      allow(processor).to receive(:resume)
+      allow(processor).to receive(:start)
       subject.start
       expect(subject).to_not be_paused
     end
 
     it 'starts adapter' do
       expect(backend).to receive(:start)
-      allow(processor).to receive(:setup)
-      allow(processor).to receive(:resume)
+      allow(processor).to receive(:start)
       subject.start
     end
   end
@@ -138,38 +136,12 @@ RSpec.describe Listener do
   describe '#stop' do
     before do
       allow(backend).to receive(:start)
-      allow(processor).to receive(:setup)
-      allow(processor).to receive(:resume)
+      allow(processor).to receive(:start)
     end
 
     context 'when fully started' do
       before do
         subject.start
-      end
-
-      it 'terminates' do
-        allow(backend).to receive(:stop)
-        allow(processor).to receive(:teardown)
-        subject.stop
-      end
-    end
-
-    context 'when frontend is ready' do
-      before do
-        subject.transition :backend_started
-        subject.transition :frontend_ready
-      end
-
-      it 'terminates' do
-        allow(backend).to receive(:stop)
-        allow(processor).to receive(:teardown)
-        subject.stop
-      end
-    end
-
-    context 'when only backend is already started' do
-      before do
-        subject.transition :backend_started
       end
 
       it 'terminates' do
@@ -195,8 +167,7 @@ RSpec.describe Listener do
   describe '#pause' do
     before do
       allow(backend).to receive(:start)
-      allow(processor).to receive(:setup)
-      allow(processor).to receive(:resume)
+      allow(processor).to receive(:start)
       subject.start
     end
     it 'sets paused to true' do
@@ -209,8 +180,7 @@ RSpec.describe Listener do
   describe 'unpause with start' do
     before do
       allow(backend).to receive(:start)
-      allow(processor).to receive(:setup)
-      allow(processor).to receive(:resume)
+      allow(processor).to receive(:start)
       subject.start
       allow(processor).to receive(:pause)
       subject.pause
@@ -225,8 +195,7 @@ RSpec.describe Listener do
   describe '#paused?' do
     before do
       allow(backend).to receive(:start)
-      allow(processor).to receive(:setup)
-      allow(processor).to receive(:resume)
+      allow(processor).to receive(:start)
       subject.start
     end
 
@@ -245,8 +214,7 @@ RSpec.describe Listener do
     context 'when processing' do
       before do
         allow(backend).to receive(:start)
-        allow(processor).to receive(:setup)
-        allow(processor).to receive(:resume)
+        allow(processor).to receive(:start)
         subject.start
       end
       it { should be_processing }
@@ -259,8 +227,7 @@ RSpec.describe Listener do
     context 'when paused' do
       before do
         allow(backend).to receive(:start)
-        allow(processor).to receive(:setup)
-        allow(processor).to receive(:resume)
+        allow(processor).to receive(:start)
         subject.start
         allow(processor).to receive(:pause)
         subject.pause

--- a/spec/lib/listen/listener_spec.rb
+++ b/spec/lib/listen/listener_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Listener do
 
       it 'terminates' do
         allow(backend).to receive(:stop)
-        allow(processor).to receive(:teardown)
+        allow(processor).to receive(:stop)
         subject.stop
       end
     end
@@ -158,7 +158,7 @@ RSpec.describe Listener do
 
       it 'terminates' do
         allow(backend).to receive(:stop)
-        allow(processor).to receive(:teardown)
+        allow(processor).to receive(:stop)
         subject.stop
       end
     end

--- a/spec/lib/listen/queue_optimizer_spec.rb
+++ b/spec/lib/listen/queue_optimizer_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Listen::QueueOptimizer do
       it { is_expected.to eq(modified: ['foo'], added: [], removed: []) }
     end
 
-    context 'with a deteted temp file' do
+    context 'with a detected temp file' do
       before { allow(config).to receive(:exist?).with(foo).and_return(false) }
 
       let(:changes) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@ if ci?
   Coveralls.wear!
 end
 
-Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
+Dir["#{__dir__}/support/**/*.rb"].each { |f| require f }
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|

--- a/spec/support/acceptance_helper.rb
+++ b/spec/support/acceptance_helper.rb
@@ -12,23 +12,20 @@
       # 2. keep the queue if we're testing for existing accumulated changes
 
       # if were testing the queue (e.g. after unpause), don't reset
-      check_already_queued = /queued_/ =~ description
-      reset_queue = !check_already_queued
+      reset_queue = /queued_/ !~ description
 
       actual.listen(reset_queue) do
-        change_fs(type, expected) unless check_already_queued
+        change_fs(type, expected) if reset_queue
       end
       actual.changes[type].include? expected
     end
 
     failure_message do |actual|
-      result = actual.changes.inspect
-      "expected #{result} to include #{description} of #{expected}"
+      "expected #{actual.changes.inspect} to include #{description} of #{expected}"
     end
 
     failure_message_when_negated do |actual|
-      result = actual.changes.inspect
-      "expected #{result} to not include #{description} of #{expected}"
+      "expected #{actual.changes.inspect} to not include #{description} of #{expected}"
     end
   end
 end

--- a/spec/support/acceptance_helper.rb
+++ b/spec/support/acceptance_helper.rb
@@ -224,8 +224,7 @@ class ListenerWrapper
     change_offset = @timed_changes.change_offset
     freeze_offset = @timed_changes.freeze_offset
 
-    msg = "Changes took #{change_offset}s (allowed lag: #{freeze_offset})s"
-    abort(msg)
+    raise "Changes took #{change_offset}s (allowed lag: #{freeze_offset})s"
   end
 
   def _relative_path(changes)


### PR DESCRIPTION
Fixes issue #481 by removing code that attempted to synchronize threads with `sleep()` and `Thread#wakeup`. That was a race condition bug since if `wakeup` ran before `sleep()`, it would be lost and the sleeping thread would simply hang.

Detailed changes:

- Use :`:Mutex`/`::ConditionVariable` to wait/wake up on state transitions. I factored this down into FSM since it's used in two state machine classes now.
- Clean up and simplify `FSM`. Enforce symbol contracts, remove unnecessary methods, rename `default_state` to `start_state` since the latter is standard FSM terminology. Also initialize with `initialize_fsm` vs `super()`.
- Use `Queue#pop` to block front-end when waiting for events.
- Combine `Loop#setup` and `Loop#resume` since they were always called consecutively. This allowed the `Listener` `:front_end_ready` state to disappear.
- Remove `Loop#resume` and `Loop#pause` since they were no-ops.
- Rename `teardown` to `stop` to be consistent. (At some point I'd like to do a similar thing with `:processing_events`. This could simply be called `:started`.)