### PR TITLE
Allow Ruby 3

### DIFF
--- a/listen.gemspec
+++ b/listen.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.executable   = 'listen'
   s.require_path = 'lib'
 
-  s.required_ruby_version = ['~> 2.2', '>= 2.2.7']
+  s.required_ruby_version = ['>= 2.2.7']
 
   s.add_dependency 'rb-fsevent', '~> 0.10', '>= 0.10.3'
   s.add_dependency 'rb-inotify', '~> 0.9', '>= 0.9.10'


### PR DESCRIPTION
This commit addresses this conflict to support Ruby version 3.

```ruby
% ruby -v
ruby 3.0.0dev (2020-08-31T09:51:59Z master 86737c509c) [x86_64-darwin20]
% bundle
Fetching gem metadata from https://rubygems.org/.........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler found conflicting requirements for the Ruby version:
  In Gemfile:
    Ruby (= 3.0.0)

    listen was resolved to 3.2.1, which depends on
      Ruby (~> 2.2, >= 2.2.7)

Ruby (~> 2.2, >= 2.2.7), which is required by gem 'listen', is not available in the local ruby installation
%
```
Fix #489

### Note
- `rake spec` are failing with Ruby 3, which also fails with Ruby2.7.1 then I do not think this is related to the Ruby version.

- Ruby on Rails master branch is running CI against the Ruby master branch, which needs this fix to address thie conflict https://buildkite.com/rails/rails/builds/71363#56e7a57e-e0cd-4cbc-8dda-a9580061536b/2402-2407