### PR TITLE
issue #494: add magic # frozen_string_literal: true comment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Create this file to use pristine/installed version of Listen for development

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 

--- a/lib/listen.rb
+++ b/lib/listen.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'logger'
 require 'weakref'
 require 'listen/logger'

--- a/lib/listen/adapter.rb
+++ b/lib/listen/adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'listen/adapter/base'
 require 'listen/adapter/bsd'
 require 'listen/adapter/darwin'

--- a/lib/listen/adapter/base.rb
+++ b/lib/listen/adapter/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'listen/options'
 require 'listen/record'
 require 'listen/change'

--- a/lib/listen/adapter/bsd.rb
+++ b/lib/listen/adapter/bsd.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Listener implementation for BSD's `kqueue`.
 # @see http://www.freebsd.org/cgi/man.cgi?query=kqueue
 # @see https://github.com/mat813/rb-kqueue/blob/master/lib/rb-kqueue/queue.rb

--- a/lib/listen/adapter/config.rb
+++ b/lib/listen/adapter/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 
 module Listen

--- a/lib/listen/adapter/darwin.rb
+++ b/lib/listen/adapter/darwin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 
 module Listen

--- a/lib/listen/adapter/linux.rb
+++ b/lib/listen/adapter/linux.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Listen
   module Adapter
     # @see https://github.com/nex3/rb-inotify

--- a/lib/listen/adapter/polling.rb
+++ b/lib/listen/adapter/polling.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Listen
   module Adapter
     # Polling Adapter that works cross-platform and

--- a/lib/listen/adapter/windows.rb
+++ b/lib/listen/adapter/windows.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Listen
   module Adapter
     # Adapter implementation for Windows `wdm`.

--- a/lib/listen/backend.rb
+++ b/lib/listen/backend.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'listen/adapter'
 require 'listen/adapter/base'
 require 'listen/adapter/config'

--- a/lib/listen/change.rb
+++ b/lib/listen/change.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'listen/file'
 require 'listen/directory'
 

--- a/lib/listen/cli.rb
+++ b/lib/listen/cli.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thor'
 require 'listen'
 require 'logger'

--- a/lib/listen/directory.rb
+++ b/lib/listen/directory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module Listen

--- a/lib/listen/event/config.rb
+++ b/lib/listen/event/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Listen
   module Event
     class Config

--- a/lib/listen/event/loop.rb
+++ b/lib/listen/event/loop.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 
 require 'timeout'

--- a/lib/listen/event/processor.rb
+++ b/lib/listen/event/processor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Listen
   module Event
     class Processor

--- a/lib/listen/event/queue.rb
+++ b/lib/listen/event/queue.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 
 require 'forwardable'

--- a/lib/listen/file.rb
+++ b/lib/listen/file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'digest/md5'
 
 module Listen

--- a/lib/listen/fsm.rb
+++ b/lib/listen/fsm.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Code copied from https://github.com/celluloid/celluloid-fsm
 
 require 'thread'

--- a/lib/listen/listener.rb
+++ b/lib/listen/listener.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'English'
 
 require 'listen/version'

--- a/lib/listen/listener/config.rb
+++ b/lib/listen/listener/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Listen
   class Listener
     class Config

--- a/lib/listen/logger.rb
+++ b/lib/listen/logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Listen
   def self.logger
     @logger ||= nil

--- a/lib/listen/options.rb
+++ b/lib/listen/options.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Listen
   class Options
     def initialize(opts, defaults)

--- a/lib/listen/queue_optimizer.rb
+++ b/lib/listen/queue_optimizer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Listen
   class QueueOptimizer
     class Config

--- a/lib/listen/record.rb
+++ b/lib/listen/record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 require 'listen/record/entry'
 require 'listen/record/symlink_detector'

--- a/lib/listen/record/entry.rb
+++ b/lib/listen/record/entry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Listen
   # @private api
   class Record

--- a/lib/listen/record/symlink_detector.rb
+++ b/lib/listen/record/symlink_detector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'set'
 
 module Listen

--- a/lib/listen/silencer.rb
+++ b/lib/listen/silencer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Listen
   class Silencer
     # The default list of directories that get ignored.

--- a/lib/listen/silencer/controller.rb
+++ b/lib/listen/silencer/controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Listen
   class Silencer
     class Controller

--- a/lib/listen/version.rb
+++ b/lib/listen/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Listen
   VERSION = '3.2.1'.freeze
 end

--- a/spec/acceptance/listen_spec.rb
+++ b/spec/acceptance/listen_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # encoding: UTF-8
 
 RSpec.describe 'Listen', acceptance: true do

--- a/spec/lib/listen/adapter/base_spec.rb
+++ b/spec/lib/listen/adapter/base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Listen::Adapter::Base do
   class FakeAdapter < described_class
     def initialize(config)

--- a/spec/lib/listen/adapter/bsd_spec.rb
+++ b/spec/lib/listen/adapter/bsd_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Listen::Adapter::BSD do
   describe 'class' do
     subject { described_class }

--- a/spec/lib/listen/adapter/config_spec.rb
+++ b/spec/lib/listen/adapter/config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'listen/adapter/config'
 
 RSpec.describe Listen::Adapter::Config do

--- a/spec/lib/listen/adapter/darwin_spec.rb
+++ b/spec/lib/listen/adapter/darwin_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This is just so stubs work
 require 'rb-fsevent'
 

--- a/spec/lib/listen/adapter/linux_spec.rb
+++ b/spec/lib/listen/adapter/linux_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Listen::Adapter::Linux do
   describe 'class' do
     subject { described_class }

--- a/spec/lib/listen/adapter/polling_spec.rb
+++ b/spec/lib/listen/adapter/polling_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 include Listen
 
 RSpec.describe Adapter::Polling do

--- a/spec/lib/listen/adapter/windows_spec.rb
+++ b/spec/lib/listen/adapter/windows_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Listen::Adapter::Windows do
   describe 'class' do
     subject { described_class }

--- a/spec/lib/listen/adapter_spec.rb
+++ b/spec/lib/listen/adapter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Listen::Adapter do
   let(:listener) { instance_double(Listen::Listener, options: {}) }
   before do

--- a/spec/lib/listen/backend_spec.rb
+++ b/spec/lib/listen/backend_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'listen/backend'
 
 RSpec.describe Listen::Backend do

--- a/spec/lib/listen/change_spec.rb
+++ b/spec/lib/listen/change_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Listen::Change do
   let(:config) { instance_double(Listen::Change::Config) }
   let(:dir) { instance_double(Pathname) }

--- a/spec/lib/listen/cli_spec.rb
+++ b/spec/lib/listen/cli_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'listen/cli'
 
 RSpec.describe Listen::CLI do

--- a/spec/lib/listen/directory_spec.rb
+++ b/spec/lib/listen/directory_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 include Listen
 
 RSpec.describe Directory do

--- a/spec/lib/listen/event/config_spec.rb
+++ b/spec/lib/listen/event/config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'listen/event/config'
 
 RSpec.describe Listen::Event::Config do

--- a/spec/lib/listen/event/loop_spec.rb
+++ b/spec/lib/listen/event/loop_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread'
 require 'listen/event/config'
 require 'listen/event/loop'

--- a/spec/lib/listen/event/processor_spec.rb
+++ b/spec/lib/listen/event/processor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'listen/event/processor'
 require 'listen/event/config'
 

--- a/spec/lib/listen/event/queue_spec.rb
+++ b/spec/lib/listen/event/queue_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'listen/event/queue'
 
 # TODO: not part of listener really

--- a/spec/lib/listen/file_spec.rb
+++ b/spec/lib/listen/file_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Listen::File do
   let(:record) do
     instance_double(

--- a/spec/lib/listen/fsm_spec.rb
+++ b/spec/lib/listen/fsm_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Listen::FSM do
   context 'simple FSM' do
     class SpecSimpleFsm

--- a/spec/lib/listen/listener/config_spec.rb
+++ b/spec/lib/listen/listener/config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'listen/listener/config'
 RSpec.describe Listen::Listener::Config do
   describe 'options' do

--- a/spec/lib/listen/listener_spec.rb
+++ b/spec/lib/listen/listener_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 include Listen
 
 RSpec.describe Listener do

--- a/spec/lib/listen/queue_optimizer_spec.rb
+++ b/spec/lib/listen/queue_optimizer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Listen::QueueOptimizer do
   let(:config) { instance_double(Listen::QueueOptimizer::Config) }
   subject { described_class.new(config) }

--- a/spec/lib/listen/record_spec.rb
+++ b/spec/lib/listen/record_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Listen::Record do
   let(:dir) { instance_double(Pathname, to_s: '/dir') }
   let(:record) { Listen::Record.new(dir) }

--- a/spec/lib/listen/silencer/controller_spec.rb
+++ b/spec/lib/listen/silencer/controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'listen/silencer/controller'
 
 RSpec.describe Listen::Silencer::Controller do

--- a/spec/lib/listen/silencer_spec.rb
+++ b/spec/lib/listen/silencer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Matchers.define :accept do |type, path|
   match { |actual| !actual.silenced?(Pathname(path), type) }
 end

--- a/spec/lib/listen_spec.rb
+++ b/spec/lib/listen_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe Listen do
   let(:listener) { instance_double(Listen::Listener, stop: nil) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # TODO: reduce requires everwhere and be more strict about it
 require 'listen'
 

--- a/spec/support/acceptance_helper.rb
+++ b/spec/support/acceptance_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 {
   modification: :modified,
   addition: :added,

--- a/spec/support/fixtures_helper.rb
+++ b/spec/support/fixtures_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'tmpdir'
 
 include FileUtils

--- a/spec/support/platform_helper.rb
+++ b/spec/support/platform_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 def darwin?
   RbConfig::CONFIG['target_os'] =~ /darwin/i
 end


### PR DESCRIPTION
- Ran [magic_frozen_string_literal](https://github.com/Invoca/magic_frozen_string_literal) to add `# frozen_string_literal: true` at the top of all Ruby files. This cuts down on string garbage that is created, so garbage collection will be run less frequently.