### PR TITLE
issue #487: unify Thread.new

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,5 +16,4 @@ AllCops:
 
 # TODO: put your overrides here:
 Style/StringLiterals:
-  EnforcedStyle: single_quotes
-  Enabled: true
+  Enabled: false

--- a/lib/listen.rb
+++ b/lib/listen.rb
@@ -5,18 +5,10 @@ require 'weakref'
 require 'listen/logger'
 require 'listen/listener'
 
-# Always set up logging by default first time file is required
-#
-# NOTE: If you need to clear the logger completely, do so *after*
-# requiring this file. If you need to set a custom logger,
-# require the listen/logger file and set the logger before requiring
-# this file.
-Listen.setup_default_logger_if_unset
-
 # Won't print anything by default because of level - unless you've set
 # LISTEN_GEM_DEBUGGING or provided your own logger with a high enough level
-Listen::Logger.info "Listen loglevel set to: #{Listen.logger.level}"
-Listen::Logger.info "Listen version: #{Listen::VERSION}"
+Listen.logger.info "Listen loglevel set to: #{Listen.logger.level}"
+Listen.logger.info "Listen version: #{Listen::VERSION}"
 
 module Listen
   @listeners = Queue.new

--- a/lib/listen/adapter.rb
+++ b/lib/listen/adapter.rb
@@ -15,15 +15,15 @@ module Listen
 
     class << self
       def select(options = {})
-        _log :debug, 'Adapter: considering polling ...'
+        Listen.logger.debug 'Adapter: considering polling ...'
         return Polling if options[:force_polling]
-        _log :debug, 'Adapter: considering optimized backend...'
+        Listen.logger.debug 'Adapter: considering optimized backend...'
         return _usable_adapter_class if _usable_adapter_class
-        _log :debug, 'Adapter: falling back to polling...'
+        Listen.logger.debug 'Adapter: falling back to polling...'
         _warn_polling_fallback(options)
         Polling
       rescue
-        _log :warn, format('Adapter: failed: %s:%s', $ERROR_POSITION.inspect,
+        Listen.logger.warn format('Adapter: failed: %s:%s', $ERROR_POSITION.inspect,
                            $ERROR_POSITION * "\n")
         raise
       end
@@ -37,10 +37,6 @@ module Listen
       def _warn_polling_fallback(options)
         msg = options.fetch(:polling_fallback_message, POLLING_FALLBACK_MESSAGE)
         Kernel.warn "[Listen warning]:\n  #{msg}" if msg
-      end
-
-      def _log(type, message)
-        Listen::Logger.send(type, message)
       end
     end
   end

--- a/lib/listen/adapter/base.rb
+++ b/lib/listen/adapter/base.rb
@@ -32,7 +32,7 @@ module Listen
       # TODO: it's a separate method as a temporary workaround for tests
       def configure
         if @configured
-          _log(:warn, 'Adapter already configured!')
+          Listen.logger.warn('Adapter already configured!')
           return
         end
 
@@ -65,7 +65,7 @@ module Listen
         configure
 
         if started?
-          _log(:warn, 'Adapter already started!')
+          Listen.logger.warn('Adapter already started!')
           return
         end
 
@@ -104,9 +104,9 @@ module Listen
         start = Time.now.to_f
         yield
         diff = Time.now.to_f - start
-        Listen::Logger.info format('%s: %.05f seconds', title, diff)
+        Listen.logger.info format('%s: %.05f seconds', title, diff)
       rescue
-        Listen::Logger.warn "#{title} crashed: #{$ERROR_INFO.inspect}"
+        Listen.logger.warn "#{title} crashed: #{$ERROR_INFO.inspect}"
         raise
       end
 
@@ -114,10 +114,6 @@ module Listen
       # e.g. Darwin -> DirRescan, INotify -> MoveScan, etc.
       def _queue_change(type, dir, rel_path, options)
         @snapshots[dir].invalidate(type, rel_path, options)
-      end
-
-      def _log(*args, &block)
-        self.class.send(:_log, *args, &block)
       end
 
       def _log_exception(msg, caller_stack)
@@ -128,18 +124,12 @@ module Listen
           caller_stack * "\n"
         )
 
-        _log(:error, formatted)
+        Listen.logger.error(formatted)
       end
 
       class << self
         def usable?
           const_get('OS_REGEXP') =~ RbConfig::CONFIG['target_os']
-        end
-
-        private
-
-        def _log(*args, &block)
-          Listen::Logger.send(*args, &block)
         end
       end
     end

--- a/lib/listen/adapter/base.rb
+++ b/lib/listen/adapter/base.rb
@@ -82,7 +82,6 @@ module Listen
             msg = 'run() in thread failed: %s:\n'\
               ' %s\n\ncalled from:\n %s'
             _log_exception(msg, calling_stack)
-            raise # for unit tests mostly
           end
         end
       end

--- a/lib/listen/adapter/base.rb
+++ b/lib/listen/adapter/base.rb
@@ -88,9 +88,8 @@ module Listen
       private
 
       def _stop
-        if thread = @run_thread
-          thread.kill.join
-        end
+        @run_thread&.kill
+        @run_thread = nil
       end
 
       def _timed(title)

--- a/lib/listen/adapter/bsd.rb
+++ b/lib/listen/adapter/bsd.rb
@@ -96,7 +96,7 @@ module Listen
       def _watch_file(path, queue)
         queue.watch_file(path, *options.events, &@callback)
       rescue Errno::ENOENT => e
-        _log :warn, "kqueue: watch file failed: #{e.message}"
+        Listen.logger.warn "kqueue: watch file failed: #{e.message}"
       end
 
       # Quick rubocop workaround

--- a/lib/listen/adapter/darwin.rb
+++ b/lib/listen/adapter/darwin.rb
@@ -68,14 +68,6 @@ module Listen
         _queue_change(:dir, dir, rel_path, recursive: true)
       end
 
-      def _run_worker(worker)
-        Listen.logger.debug { "fsevent: running worker: #{worker.inspect}" }
-        worker.run
-      rescue
-        format_string = 'fsevent: running worker failed: %s:%s called from: %s'
-        _log_exception format_string, caller
-      end
-
       def _stop
         @worker_thread&.kill
         super

--- a/lib/listen/adapter/darwin.rb
+++ b/lib/listen/adapter/darwin.rb
@@ -44,7 +44,7 @@ module Listen
         require 'rb-fsevent'
         worker = FSEvent.new
         dirs_to_watch = @callbacks.keys.map(&:to_s)
-        _log(:info) { "fsevent: watching: #{dirs_to_watch.inspect}" }
+        Listen.logger.info { "fsevent: watching: #{dirs_to_watch.inspect}" }
         worker.watch(dirs_to_watch, { latency: options.latency }, &method(:_process_changes))
         @worker_thread = Thread.new { _run_worker(worker) }
       end
@@ -62,14 +62,14 @@ module Listen
       end
 
       def _process_event(dir, path)
-        _log(:debug) { "fsevent: processing path: #{path.inspect}" }
+        Listen.logger.debug { "fsevent: processing path: #{path.inspect}" }
         # TODO: does this preserve symlinks?
         rel_path = path.relative_path_from(dir).to_s
         _queue_change(:dir, dir, rel_path, recursive: true)
       end
 
       def _run_worker(worker)
-        _log(:debug) { "fsevent: running worker: #{worker.inspect}" }
+        Listen.logger.debug { "fsevent: running worker: #{worker.inspect}" }
         worker.run
       rescue
         format_string = 'fsevent: running worker failed: %s:%s called from: %s'

--- a/lib/listen/adapter/darwin.rb
+++ b/lib/listen/adapter/darwin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'thread'
+require 'listen/thread'
 
 module Listen
   module Adapter
@@ -46,7 +46,10 @@ module Listen
         dirs_to_watch = @callbacks.keys.map(&:to_s)
         Listen.logger.info { "fsevent: watching: #{dirs_to_watch.inspect}" }
         worker.watch(dirs_to_watch, { latency: options.latency }, &method(:_process_changes))
-        @worker_thread = Thread.new { _run_worker(worker) }
+        @worker_thread = Listen::Thread.new("worker_thread") do
+          _log(:debug) { "fsevent: running worker: #{worker.inspect}" }
+          worker.run
+        end
       end
 
       def _process_changes(dirs)

--- a/lib/listen/adapter/darwin.rb
+++ b/lib/listen/adapter/darwin.rb
@@ -80,7 +80,7 @@ module Listen
       end
 
       def _stop
-        @worker_thread.kill.join if (@worker_thread ||= nil)
+        @worker_thread&.kill
         super
       end
     end

--- a/lib/listen/adapter/darwin.rb
+++ b/lib/listen/adapter/darwin.rb
@@ -46,10 +46,7 @@ module Listen
         dirs_to_watch = @callbacks.keys.map(&:to_s)
         Listen.logger.info { "fsevent: watching: #{dirs_to_watch.inspect}" }
         worker.watch(dirs_to_watch, { latency: options.latency }, &method(:_process_changes))
-        @worker_thread = Listen::Thread.new("worker_thread") do
-          _log(:debug) { "fsevent: running worker: #{worker.inspect}" }
-          worker.run
-        end
+        @worker_thread = Listen::Thread.new("worker_thread") { worker.run }
       end
 
       def _process_changes(dirs)

--- a/lib/listen/adapter/linux.rb
+++ b/lib/listen/adapter/linux.rb
@@ -47,7 +47,7 @@ module Listen
         path = Pathname.new(event.watcher.path) + event.name
         rel_path = path.relative_path_from(dir).to_s
 
-        _log(:debug) { "inotify: #{rel_path} (#{event.flags.inspect})" }
+        Listen.logger.debug { "inotify: #{rel_path} (#{event.flags.inspect})" }
 
         if /1|true/ =~ ENV['LISTEN_GEM_SIMULATE_FSEVENT']
           if (event.flags & [:moved_to, :moved_from]) || _dir_event?(event)

--- a/lib/listen/adapter/windows.rb
+++ b/lib/listen/adapter/windows.rb
@@ -17,7 +17,7 @@ module Listen
         require 'wdm'
         true
       rescue LoadError
-        _log :debug, format('wdm - load failed: %s:%s', $ERROR_INFO,
+        Listen.logger.debug format('wdm - load failed: %s:%s', $ERROR_INFO,
                             $ERROR_POSITION * "\n")
 
         Kernel.warn BUNDLER_DECLARE_GEM
@@ -28,7 +28,7 @@ module Listen
 
       def _configure(dir)
         require 'wdm'
-        _log :debug, 'wdm - starting...'
+        Listen.logger.debug 'wdm - starting...'
         @worker ||= WDM::Monitor.new
         @worker.watch_recursively(dir.to_s, :files) do |change|
           yield([:file, change])
@@ -49,7 +49,7 @@ module Listen
       end
 
       def _process_event(dir, event)
-        _log :debug, "wdm - callback: #{event.inspect}"
+        Listen.logger.debug "wdm - callback: #{event.inspect}"
 
         type, change = event
 
@@ -82,7 +82,7 @@ module Listen
         end
       rescue
         details = event.inspect
-        _log :error, format('wdm - callback (%s): %s:%s', details, $ERROR_INFO,
+        Listen.logger.error format('wdm - callback (%s): %s:%s', details, $ERROR_INFO,
                             $ERROR_POSITION * "\n")
         raise
       end

--- a/lib/listen/change.rb
+++ b/lib/listen/change.rb
@@ -37,13 +37,13 @@ module Listen
       cookie = options[:cookie]
 
       if !cookie && config.silenced?(rel_path, type)
-        Listen::Logger.debug { "(silenced): #{rel_path.inspect}" }
+        Listen.logger.debug { "(silenced): #{rel_path.inspect}" }
         return
       end
 
       path = watched_dir + rel_path
 
-      Listen::Logger.debug do
+      Listen.logger.debug do
         log_details = options[:silence] && 'recording' || change || 'unknown'
         "#{log_details}: #{type}:#{path} (#{options.inspect})"
       end
@@ -67,7 +67,7 @@ module Listen
         __method__,
         exinspect,
         ex.backtrace * "\n")
-      Listen::Logger.error(msg)
+      Listen.logger.error(msg)
       raise
     end
 

--- a/lib/listen/cli.rb
+++ b/lib/listen/cli.rb
@@ -37,8 +37,7 @@ module Listen
     attr_reader :logger
     def initialize(options)
       @options = options
-      @logger = ::Logger.new(STDOUT)
-      @logger.level = ::Logger::INFO
+      @logger = ::Logger.new(STDOUT, level: ::Logger::INFO)
       @logger.formatter = proc { |_, _, _, msg| "#{msg}\n" }
     end
 

--- a/lib/listen/directory.rb
+++ b/lib/listen/directory.rb
@@ -16,7 +16,7 @@ module Listen
       path = dir + rel_path
       current = Set.new(_children(path))
 
-      Listen::Logger.debug do
+      Listen.logger.debug do
         format('%s: %s(%s): %s -> %s',
                (options[:silence] ? 'Recording' : 'Scanning'),
                rel_path, options.inspect, previous.inspect, current.inspect)
@@ -49,7 +49,7 @@ module Listen
       _async_changes(snapshot, path, previous, options)
       _change(snapshot, :file, rel_path, options)
     rescue
-      Listen::Logger.warn do
+      Listen.logger.warn do
         format('scan DIED: %s:%s', $ERROR_INFO, $ERROR_POSITION * "\n")
       end
       raise

--- a/lib/listen/event/loop.rb
+++ b/lib/listen/event/loop.rb
@@ -68,7 +68,7 @@ module Listen
         transition! :stopped
 
         if @wait_thread.alive?
-          @wait_thread.join.kill
+          @wait_thread.join
         end
         @wait_thread = nil
       end

--- a/lib/listen/event/loop.rb
+++ b/lib/listen/event/loop.rb
@@ -49,12 +49,12 @@ module Listen
           _process_changes
         end
 
-        Listen::Logger.debug("Waiting for processing to start...")
+        Listen.logger.debug("Waiting for processing to start...")
 
         wait_for_state(:started, MAX_STARTUP_SECONDS) or
           raise Error::NotStarted, "thread didn't start in #{MAX_STARTUP_SECONDS} seconds (in state: #{state.inspect})"
 
-        Listen::Logger.debug('Processing started.')
+        Listen.logger.debug('Processing started.')
       end
 
       def pause
@@ -97,7 +97,7 @@ module Listen
           indent,
           ex.backtrace * indent
         )
-        Listen::Logger.error(msg)
+        Listen.logger.error(msg)
       end
 
       def _wakeup(reason)

--- a/lib/listen/event/loop.rb
+++ b/lib/listen/event/loop.rb
@@ -85,20 +85,6 @@ module Listen
         transition! :started
 
         processor.loop_for(@config.min_delay_between_events)
-
-      rescue StandardError => ex
-        _nice_error(ex)
-      end
-
-      def _nice_error(ex)
-        indent = "\n -- "
-        msg = format(
-          'exception while processing events: %s Backtrace:%s%s',
-          ex,
-          indent,
-          ex.backtrace * indent
-        )
-        Listen::Logger.error(msg)
       end
 
       def _wakeup(reason)

--- a/lib/listen/event/loop.rb
+++ b/lib/listen/event/loop.rb
@@ -4,6 +4,7 @@ require 'thread'
 
 require 'timeout'
 require 'listen/event/processor'
+require 'listen/thread'
 
 module Listen
   module Event
@@ -45,7 +46,7 @@ module Listen
 
         transition! :starting
 
-        @wait_thread = Thread.new do
+        @wait_thread = Listen::Thread.new("wait_thread") do
           _process_changes
         end
 
@@ -97,7 +98,7 @@ module Listen
           indent,
           ex.backtrace * indent
         )
-        Listen.logger.error(msg)
+        Listen::Logger.error(msg)
       end
 
       def _wakeup(reason)

--- a/lib/listen/event/processor.rb
+++ b/lib/listen/event/processor.rb
@@ -23,7 +23,7 @@ module Listen
           _process_changes(event)
         end
       rescue Stopped
-        Listen::Logger.debug('Processing stopped')
+        Listen.logger.debug('Processing stopped')
       end
 
       private
@@ -115,7 +115,7 @@ module Listen
 
         block_start = _timestamp
         config.call(*result)
-        Listen::Logger.debug "Callback took #{_timestamp - block_start} sec"
+        Listen.logger.debug "Callback took #{_timestamp - block_start} sec"
       end
 
       attr_reader :config

--- a/lib/listen/file.rb
+++ b/lib/listen/file.rb
@@ -71,7 +71,7 @@ module Listen
       record.unset_path(rel_path)
       :removed
     rescue
-      Listen::Logger.debug "lstat failed for: #{rel_path} (#{$ERROR_INFO})"
+      Listen.logger.debug "lstat failed for: #{rel_path} (#{$ERROR_INFO})"
       raise
     end
 

--- a/lib/listen/options.rb
+++ b/lib/listen/options.rb
@@ -12,7 +12,7 @@ module Listen
       return if given_options.empty?
 
       msg = "Unknown options: #{given_options.inspect}"
-      Listen::Logger.warn msg
+      Listen.logger.warn msg
       fail msg
     end
 

--- a/lib/listen/thread.rb
+++ b/lib/listen/thread.rb
@@ -1,0 +1,43 @@
+require 'thread'
+
+require_relative 'logger'
+
+module Listen
+  module Thread
+    class << self
+      # Creates a new thread with the given name.
+      # Any exceptions raised by the thread will be logged with the thread name and complete backtrace.
+      def new(name)
+        thread_name = "listen-#{name}"
+
+        caller_stack = caller
+        ::Thread.new do
+          yield
+        rescue Exception => ex
+          _log_exception(ex, thread_name, caller_stack)
+          nil
+        end.tap do |thread|
+          thread.name = thread_name
+        end
+      end
+
+      private
+
+      def _log_exception(ex, thread_name, caller_stack)
+        complete_backtrace = [*ex.backtrace, "--- Thread.new ---", *caller_stack]
+        message = "Exception rescued in #{thread_name}:\n#{_exception_with_causes(ex)}\n#{complete_backtrace * "\n"}"
+        Listen::Logger.error(message)
+      end
+
+      def _exception_with_causes(ex)
+        result = +"#{ex.class}: #{ex}"
+        if ex.cause
+          result << "\n"
+          result << "--- Caused by: ---\n"
+          result << _exception_with_causes(ex.cause)
+        end
+        result
+      end
+    end
+  end
+end

--- a/lib/listen/thread.rb
+++ b/lib/listen/thread.rb
@@ -28,7 +28,7 @@ module Listen
       def _log_exception(ex, thread_name, caller_stack)
         complete_backtrace = [*ex.backtrace, "--- Thread.new ---", *caller_stack]
         message = "Exception rescued in #{thread_name}:\n#{_exception_with_causes(ex)}\n#{complete_backtrace * "\n"}"
-        Listen::Logger.error(message)
+        Listen.logger.error(message)
       end
 
       def _exception_with_causes(ex)

--- a/lib/listen/thread.rb
+++ b/lib/listen/thread.rb
@@ -12,10 +12,12 @@ module Listen
 
         caller_stack = caller
         ::Thread.new do
-          yield
-        rescue Exception => ex
-          _log_exception(ex, thread_name, caller_stack)
-          nil
+          begin
+            yield
+          rescue Exception => ex
+            _log_exception(ex, thread_name, caller_stack)
+            nil
+          end
         end.tap do |thread|
           thread.name = thread_name
         end

--- a/spec/acceptance/listen_spec.rb
+++ b/spec/acceptance/listen_spec.rb
@@ -18,17 +18,6 @@ RSpec.describe 'Listen', acceptance: true do
     let(:paths) { Pathname.new(Dir.pwd) }
     around { |example| fixtures { example.run } }
 
-    context 'with change block raising' do
-      let(:callback) { ->(_, _, _) { raise 'foo' } }
-      let(:wrapper) { setup_listener(all_options, callback) }
-
-      it 'warns the backtrace' do
-        expect(Listen.logger).to receive(:error).
-          with(/exception while processing events: foo.*Backtrace:/)
-        wrapper.listen { touch 'file.rb' }
-      end
-    end
-
     modes =
       case ENV['TEST_LISTEN_ADAPTER_MODES'] || 'both'
       when 'polling'

--- a/spec/acceptance/listen_spec.rb
+++ b/spec/acceptance/listen_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Listen', acceptance: true do
     around { |example| fixtures { example.run } }
 
     context 'with change block raising' do
-      let(:callback) { ->(_, _, _) { fail 'foo' } }
+      let(:callback) { ->(_, _, _) { raise 'foo' } }
       let(:wrapper) { setup_listener(all_options, callback) }
 
       it 'warns the backtrace' do

--- a/spec/acceptance/listen_spec.rb
+++ b/spec/acceptance/listen_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Listen', acceptance: true do
       let(:wrapper) { setup_listener(all_options, callback) }
 
       it 'warns the backtrace' do
-        expect(Listen::Logger).to receive(:error).
+        expect(Listen.logger).to receive(:error).
           with(/exception while processing events: foo.*Backtrace:/)
         wrapper.listen { touch 'file.rb' }
       end

--- a/spec/lib/listen/adapter/base_spec.rb
+++ b/spec/lib/listen/adapter/base_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Listen::Adapter::Base do
     end
   end
 
+  let(:thread) { instance_double(Thread, "thread") }
   let(:dir1) { instance_double(Pathname, 'dir1', to_s: '/foo/dir1') }
 
   let(:config) { instance_double(Listen::Adapter::Config) }
@@ -43,7 +44,11 @@ RSpec.describe Listen::Adapter::Base do
     allow(config).to receive(:silencer).and_return(silencer)
     allow(config).to receive(:adapter_options).and_return(adapter_options)
 
-    allow(Thread).to receive(:new) { |&block| block.call }
+    allow(Thread).to receive(:new) do |&block|
+      block.call
+      allow(thread).to receive(:name=)
+      thread
+    end
 
     # Stuff that happens in configure()
     allow(Listen::Record).to receive(:new).with(dir1).and_return(record)

--- a/spec/lib/listen/adapter/polling_spec.rb
+++ b/spec/lib/listen/adapter/polling_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe Adapter::Polling do
         t = Thread.new { subject.start }
         sleep 0.25
         t.kill
-        t.join
       end
     end
 

--- a/spec/lib/listen/event/loop_spec.rb
+++ b/spec/lib/listen/event/loop_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Listen::Event::Loop do
 
     describe '#stop' do
       before do
-        allow(thread).to receive_message_chain(:join, :kill)
+        allow(thread).to receive(:join)
       end
 
       it 'frees the thread' do
@@ -92,7 +92,7 @@ RSpec.describe Listen::Event::Loop do
       end
 
       it 'waits for the thread to finish' do
-        expect(thread).to receive_message_chain(:join, :kill)
+        expect(thread).to receive(:join)
         subject.stop
       end
 

--- a/spec/lib/listen/event/loop_spec.rb
+++ b/spec/lib/listen/event/loop_spec.rb
@@ -7,7 +7,7 @@ require 'listen/event/loop'
 RSpec.describe Listen::Event::Loop do
   let(:config) { instance_double(Listen::Event::Config, 'config') }
   let(:processor) { instance_double(Listen::Event::Processor, 'processor') }
-  let(:thread) { instance_double(Thread) }
+  let(:thread) { instance_double(Thread, 'thread') }
 
   let(:reasons) { instance_double(::Queue, 'reasons') }
   let(:ready) { instance_double(::Queue, 'ready') }
@@ -33,6 +33,7 @@ RSpec.describe Listen::Event::Loop do
 
     allow(config).to receive(:min_delay_between_events).and_return(1.234)
 
+    allow(thread).to receive(:name=)
     allow(Thread).to receive(:new) do |*_, &block|
       blocks[:thread_block] = block
       thread
@@ -40,12 +41,6 @@ RSpec.describe Listen::Event::Loop do
 
     allow(Kernel).to receive(:sleep) do |*args|
       fail "stub called: sleep(#{args.map(&:inspect) * ','})"
-    end
-
-    allow(subject).to receive(:_nice_error) do |ex|
-      indent = "\n -- "
-      backtrace = ex.backtrace.reject { |line| line =~ %r{\/gems\/} }
-      fail "error called: #{ex}: #{indent}#{backtrace * indent}"
     end
   end
 

--- a/spec/lib/listen/logger_spec.rb
+++ b/spec/lib/listen/logger_spec.rb
@@ -1,0 +1,84 @@
+require 'listen/logger'
+
+RSpec.describe 'Listen.logger' do
+  ENV_VARIABLE_NAME = 'LISTEN_GEM_DEBUGGING'
+
+  let(:logger) { instance_double(::Logger, "logger") }
+
+  around do |spec|
+    orig_logger = Listen.instance_variable_get(:@logger)
+
+    spec.run
+
+    Listen.logger = orig_logger
+  end
+
+  around do |spec|
+    orig_debugging_env_variable = ENV.fetch(ENV_VARIABLE_NAME, :not_set)
+
+    spec.run
+
+    if orig_debugging_env_variable == :not_set
+      ENV.delete(ENV_VARIABLE_NAME)
+    else
+      ENV[ENV_VARIABLE_NAME] = orig_debugging_env_variable
+    end
+  end
+
+  describe 'logger=' do
+    it 'allows the logger to be set' do
+      Listen.logger = logger
+      expect(Listen.logger).to be(logger)
+    end
+
+    it 'allows nil to be set (implying default logger)' do
+      Listen.logger = nil
+      expect(Listen.logger).to be_kind_of(::Logger)
+    end
+  end
+
+  describe 'logger' do
+    before do
+      Listen.instance_variable_set(:@logger, nil)
+    end
+
+    it 'returns default logger if none set' do
+      expect(Listen.logger).to be_kind_of(::Logger)
+    end
+
+    ['debug', 'DEBUG', '2', 'level2', '2 '].each do |env_value|
+      it "infers DEBUG level from #{ENV_VARIABLE_NAME}=#{env_value.inspect}" do
+        ENV[ENV_VARIABLE_NAME] = env_value
+        expect(Listen.logger.level).to eq(::Logger::DEBUG)
+      end
+    end
+
+    ['info', 'INFO', 'true', ' true', 'TRUE', 'TRUE ', 'yes', 'YES', ' yesss!', '1', 'level1'].each do |env_value|
+      it "infers INFO level from #{ENV_VARIABLE_NAME}=#{env_value.inspect}" do
+        ENV[ENV_VARIABLE_NAME] = env_value
+        expect(Listen.logger.level).to eq(::Logger::INFO)
+      end
+    end
+
+    ['warn', 'WARN', ' warn', 'warning'].each do |env_value|
+      it "infers WARN level from #{ENV_VARIABLE_NAME}=#{env_value.inspect}" do
+        ENV[ENV_VARIABLE_NAME] = env_value
+        expect(Listen.logger.level).to eq(::Logger::WARN)
+      end
+    end
+
+    ['error', 'ERROR', 'OTHER'].each do |env_value|
+      it "infers ERROR level from #{ENV_VARIABLE_NAME}=#{env_value.inspect}" do
+        ENV[ENV_VARIABLE_NAME] = env_value
+        expect(Listen.logger.level).to eq(::Logger::ERROR)
+      end
+    end
+
+    ['fatal', 'FATAL', ' fatal'].each do |env_value|
+      it "infers FATAL level from #{ENV_VARIABLE_NAME}=#{env_value.inspect}" do
+        ENV[ENV_VARIABLE_NAME] = env_value
+        expect(Listen.logger.level).to eq(::Logger::FATAL)
+      end
+    end
+  end
+end

--- a/spec/lib/listen/thread_spec.rb
+++ b/spec/lib/listen/thread_spec.rb
@@ -1,0 +1,54 @@
+require 'listen/thread'
+
+RSpec.describe Listen::Thread do
+  let(:name) { "worker_thread" }
+  let(:block) { -> { } }
+  subject { described_class.new(name, &block) }
+
+  it "calls Thread.new" do
+    expect(Thread).to receive(:new) do
+      thread = instance_double(Thread, "thread")
+      expect(thread).to receive(:name=).with("listen-#{name}")
+      thread
+    end
+    subject
+  end
+
+  context "when exception raised" do
+    let(:block) do
+      -> { raise ArgumentError, 'boom!' }
+    end
+
+    it "rescues and logs exceptions" do
+      expect(Listen::Logger).to receive(:error)
+        .with(/Exception rescued in listen-worker_thread:\nArgumentError: boom!\n.*\/listen\/thread_spec\.rb/)
+      subject.join
+    end
+
+    it "rescues and logs backtrace + exception backtrace" do
+      expect(Listen::Logger).to receive(:error)
+        .with(/Exception rescued in listen-worker_thread:\nArgumentError: boom!\n.*\/listen\/thread\.rb.*--- Thread.new ---.*\/listen\/thread_spec\.rb/m)
+      subject.join
+    end
+  end
+
+  context "when nested exceptions raised" do
+    let(:block) do
+      -> do
+        begin
+          raise ArgumentError, 'boom!'
+        rescue
+          raise 'nested inner'
+        end
+      rescue
+        raise 'nested outer'
+      end
+    end
+
+    it "details exception causes" do
+      expect(Listen::Logger).to receive(:error)
+        .with(/RuntimeError: nested outer\n--- Caused by: ---\nRuntimeError: nested inner\n--- Caused by: ---\nArgumentError: boom!/)
+      subject.join
+    end
+  end
+end

--- a/spec/lib/listen/thread_spec.rb
+++ b/spec/lib/listen/thread_spec.rb
@@ -36,12 +36,14 @@ RSpec.describe Listen::Thread do
     let(:block) do
       -> do
         begin
-          raise ArgumentError, 'boom!'
+          begin
+            raise ArgumentError, 'boom!'
+          rescue
+            raise 'nested inner'
+          end
         rescue
-          raise 'nested inner'
+          raise 'nested outer'
         end
-      rescue
-        raise 'nested outer'
       end
     end
 

--- a/spec/lib/listen/thread_spec.rb
+++ b/spec/lib/listen/thread_spec.rb
@@ -20,13 +20,13 @@ RSpec.describe Listen::Thread do
     end
 
     it "rescues and logs exceptions" do
-      expect(Listen::Logger).to receive(:error)
+      expect(Listen.logger).to receive(:error)
         .with(/Exception rescued in listen-worker_thread:\nArgumentError: boom!\n.*\/listen\/thread_spec\.rb/)
       subject.join
     end
 
     it "rescues and logs backtrace + exception backtrace" do
-      expect(Listen::Logger).to receive(:error)
+      expect(Listen.logger).to receive(:error)
         .with(/Exception rescued in listen-worker_thread:\nArgumentError: boom!\n.*\/listen\/thread\.rb.*--- Thread.new ---.*\/listen\/thread_spec\.rb/m)
       subject.join
     end
@@ -48,7 +48,7 @@ RSpec.describe Listen::Thread do
     end
 
     it "details exception causes" do
-      expect(Listen::Logger).to receive(:error)
+      expect(Listen.logger).to receive(:error)
         .with(/RuntimeError: nested outer\n--- Caused by: ---\nRuntimeError: nested inner\n--- Caused by: ---\nArgumentError: boom!/)
       subject.join
     end


### PR DESCRIPTION
Issue #487:
- Unify thread creation through new `Listen::Thread` module.
- Set the `Thread#name =` property to assist with debugging in the surrounding process.
- `rescue` all exceptions in `Listen::Thread` and log them, including complete call stack (caller + exception backtrace) and show `cause` detail if any.
- Only call one of `Thread#join`, `Thread.kill`.