### PR TITLE
Issue #505: rescue and log exceptions raised in callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The `listen` gem listens to file modifications and notifies you about the change
 * You can watch multiple directories.
 * Regexp-patterns for ignoring paths for more accuracy and speed
 * Increased change detection accuracy on OS X HFS and VFAT volumes.
-* Tested on selected Ruby environments via [Travis CI](https://travis-ci.org/guard/listen). (See [.travis.yml](https:///github.com/guard/listen/master/.travis.yml) for supported/tested Ruby Versions),
+* Continuous Integration: tested on selected Ruby environments via [Github Workflows](https:///github.com/guard/listen/master/.github/workflows).
 
 ## Issues / limitations
 

--- a/lib/listen/event/processor.rb
+++ b/lib/listen/event/processor.rb
@@ -114,8 +114,12 @@ module Listen
         return if result.all?(&:empty?)
 
         block_start = _timestamp
-        config.call(*result)
-        Listen.logger.debug "Callback took #{_timestamp - block_start} sec"
+        exception_note = " (exception)"
+        ::Listen::Thread.rescue_and_log('_process_changes') do
+          config.call(*result)
+          exception_note = nil
+        end
+        Listen.logger.debug "Callback#{exception_note} took #{_timestamp - block_start} sec"
       end
 
       attr_reader :config

--- a/lib/listen/thread.rb
+++ b/lib/listen/thread.rb
@@ -9,26 +9,31 @@ module Listen
     class << self
       # Creates a new thread with the given name.
       # Any exceptions raised by the thread will be logged with the thread name and complete backtrace.
-      def new(name)
+      def new(name, &block)
         thread_name = "listen-#{name}"
-
         caller_stack = caller
+
         ::Thread.new do
-          begin
-            yield
-          rescue Exception => ex
-            _log_exception(ex, thread_name, caller_stack)
-            nil
-          end
+          rescue_and_log(thread_name, caller_stack: caller_stack, &block)
         end.tap do |thread|
           thread.name = thread_name
         end
       end
 
+      def rescue_and_log(method_name, *args, caller_stack: nil)
+        yield *args
+      rescue Exception => ex
+        _log_exception(ex, method_name, caller_stack: caller_stack)
+      end
+
       private
 
-      def _log_exception(ex, thread_name, caller_stack)
-        complete_backtrace = [*ex.backtrace, "--- Thread.new ---", *caller_stack]
+      def _log_exception(ex, thread_name, caller_stack: nil)
+        complete_backtrace = if caller_stack
+                               [*ex.backtrace, "--- Thread.new ---", *caller_stack]
+                             else
+                               ex.backtrace
+                             end
         message = "Exception rescued in #{thread_name}:\n#{_exception_with_causes(ex)}\n#{complete_backtrace * "\n"}"
         Listen.logger.error(message)
       end

--- a/lib/listen/thread.rb
+++ b/lib/listen/thread.rb
@@ -21,7 +21,7 @@ module Listen
       end
 
       def rescue_and_log(method_name, *args, caller_stack: nil)
-        yield *args
+        yield(*args)
       rescue Exception => ex
         _log_exception(ex, method_name, caller_stack: caller_stack)
       end

--- a/spec/lib/listen/event/processor_spec.rb
+++ b/spec/lib/listen/event/processor_spec.rb
@@ -222,4 +222,29 @@ RSpec.describe Listen::Event::Processor do
       end
     end
   end
+
+  describe '_process_changes' do
+    context 'when it raises an exception derived from StandardError or not' do
+      before do
+        allow(event_queue).to receive(:empty?).and_return(true)
+        allow(config).to receive(:callable?).and_return(true)
+        resulting_changes = { modified: ['foo'], added: [], removed: [] }
+        allow(config).to receive(:optimize_changes).with(anything).and_return(resulting_changes)
+        expect(config).to receive(:call).and_raise(ArgumentError, "bang!")
+        expect(config).to receive(:call).and_return(nil)
+        expect(config).to receive(:call).and_raise(ScriptError, "ruby typo!")
+      end
+
+      it 'rescues and logs exception and continues' do
+        expect(Listen.logger).to receive(:error).with(/Exception rescued in _process_changes:\nArgumentError: bang!/)
+        expect(Listen.logger).to receive(:error).with(/Exception rescued in _process_changes:\nScriptError: ruby typo!/)
+        expect(Listen.logger).to receive(:debug).with(/Callback \(exception\) took/)
+        expect(Listen.logger).to receive(:debug).with(/Callback took/)
+        expect(Listen.logger).to receive(:debug).with(/Callback \(exception\) took/)
+        subject.send(:_process_changes, event)
+        subject.send(:_process_changes, event)
+        subject.send(:_process_changes, event)
+      end
+    end
+  end
 end

--- a/spec/lib/listen/thread_spec.rb
+++ b/spec/lib/listen/thread_spec.rb
@@ -43,14 +43,14 @@ RSpec.describe Listen::Thread do
       end
 
       it "rescues and logs exceptions" do
-        expect(Listen.logger).to receive(:error)
-          .with(/Exception rescued in listen-worker_thread:\nArgumentError: boom!\n.*\/listen\/thread_spec\.rb/)
+        expect(Listen.logger).to receive(:error).
+          with(/Exception rescued in listen-worker_thread:\nArgumentError: boom!\n.*\/listen\/thread_spec\.rb/)
         subject.join
       end
 
       it "rescues and logs backtrace + exception backtrace" do
-        expect(Listen.logger).to receive(:error)
-          .with(/Exception rescued in listen-worker_thread:\nArgumentError: boom!\n.*\/listen\/thread\.rb.*--- Thread.new ---.*\/listen\/thread_spec\.rb/m)
+        expect(Listen.logger).to receive(:error).
+          with(/Exception rescued in listen-worker_thread:\nArgumentError: boom!\n.*\/listen\/thread\.rb.*--- Thread.new ---.*\/listen\/thread_spec\.rb/m)
         subject.join
       end
     end
@@ -59,8 +59,8 @@ RSpec.describe Listen::Thread do
       let(:block) { raise_nested_exception_block }
 
       it "details exception causes" do
-        expect(Listen.logger).to receive(:error)
-          .with(/RuntimeError: nested outer\n--- Caused by: ---\nRuntimeError: nested inner\n--- Caused by: ---\nArgumentError: boom!/)
+        expect(Listen.logger).to receive(:error).
+          with(/RuntimeError: nested outer\n--- Caused by: ---\nRuntimeError: nested inner\n--- Caused by: ---\nArgumentError: boom!/)
         subject.join
       end
     end
@@ -77,8 +77,8 @@ RSpec.describe Listen::Thread do
 
   describe '.rescue_and_log' do
     it 'rescues and logs nested exceptions' do
-      expect(Listen.logger).to receive(:error)
-       .with(/Exception rescued in method:\nRuntimeError: nested outer\n--- Caused by: ---\nRuntimeError: nested inner\n--- Caused by: ---\nArgumentError: boom!/) do |message|
+      expect(Listen.logger).to receive(:error).
+        with(/Exception rescued in method:\nRuntimeError: nested outer\n--- Caused by: ---\nRuntimeError: nested inner\n--- Caused by: ---\nArgumentError: boom!/) do |message|
         expect(message).to_not match(/Thread\.new/)
       end
       described_class.rescue_and_log("method", &raise_nested_exception_block)

--- a/spec/lib/listen/thread_spec.rb
+++ b/spec/lib/listen/thread_spec.rb
@@ -3,56 +3,94 @@
 require 'listen/thread'
 
 RSpec.describe Listen::Thread do
-  let(:name) { "worker_thread" }
-  let(:block) { -> { } }
-  subject { described_class.new(name, &block) }
-
-  it "calls Thread.new" do
-    expect(Thread).to receive(:new) do
-      thread = instance_double(Thread, "thread")
-      expect(thread).to receive(:name=).with("listen-#{name}")
-      thread
-    end
-    subject
-  end
-
-  context "when exception raised" do
-    let(:block) do
-      -> { raise ArgumentError, 'boom!' }
-    end
-
-    it "rescues and logs exceptions" do
-      expect(Listen.logger).to receive(:error)
-        .with(/Exception rescued in listen-worker_thread:\nArgumentError: boom!\n.*\/listen\/thread_spec\.rb/)
-      subject.join
-    end
-
-    it "rescues and logs backtrace + exception backtrace" do
-      expect(Listen.logger).to receive(:error)
-        .with(/Exception rescued in listen-worker_thread:\nArgumentError: boom!\n.*\/listen\/thread\.rb.*--- Thread.new ---.*\/listen\/thread_spec\.rb/m)
-      subject.join
-    end
-  end
-
-  context "when nested exceptions raised" do
-    let(:block) do
-      -> do
+  let(:raise_nested_exception_block) do
+    -> do
+      begin
         begin
-          begin
-            raise ArgumentError, 'boom!'
-          rescue
-            raise 'nested inner'
-          end
+          raise ArgumentError, 'boom!'
         rescue
-          raise 'nested outer'
+          raise 'nested inner'
         end
+      rescue
+        raise 'nested outer'
+      end
+    end
+  end
+
+  let(:raise_script_error_block) do
+    -> do
+      raise ScriptError, "ruby typo!"
+    end
+  end
+
+  describe '.new' do
+    let(:name) { "worker_thread" }
+    let(:block) { -> { } }
+    subject { described_class.new(name, &block) }
+
+    it "calls Thread.new" do
+      expect(Thread).to receive(:new) do
+        thread = instance_double(Thread, "thread")
+        expect(thread).to receive(:name=).with("listen-#{name}")
+        thread
+      end
+      subject
+    end
+
+    context "when exception raised" do
+      let(:block) do
+        -> { raise ArgumentError, 'boom!' }
+      end
+
+      it "rescues and logs exceptions" do
+        expect(Listen.logger).to receive(:error)
+          .with(/Exception rescued in listen-worker_thread:\nArgumentError: boom!\n.*\/listen\/thread_spec\.rb/)
+        subject.join
+      end
+
+      it "rescues and logs backtrace + exception backtrace" do
+        expect(Listen.logger).to receive(:error)
+          .with(/Exception rescued in listen-worker_thread:\nArgumentError: boom!\n.*\/listen\/thread\.rb.*--- Thread.new ---.*\/listen\/thread_spec\.rb/m)
+        subject.join
       end
     end
 
-    it "details exception causes" do
+    context "when nested exceptions raised" do
+      let(:block) { raise_nested_exception_block }
+
+      it "details exception causes" do
+        expect(Listen.logger).to receive(:error)
+          .with(/RuntimeError: nested outer\n--- Caused by: ---\nRuntimeError: nested inner\n--- Caused by: ---\nArgumentError: boom!/)
+        subject.join
+      end
+    end
+
+    context 'when exception raised that is not derived from StandardError' do
+      let(:block) { raise_script_error_block }
+
+      it "still rescues and logs" do
+        expect(Listen.logger).to receive(:error).with(/Exception rescued in listen-worker_thread:\nScriptError: ruby typo!/)
+        subject.join
+      end
+    end
+  end
+
+  describe '.rescue_and_log' do
+    it 'rescues and logs nested exceptions' do
       expect(Listen.logger).to receive(:error)
-        .with(/RuntimeError: nested outer\n--- Caused by: ---\nRuntimeError: nested inner\n--- Caused by: ---\nArgumentError: boom!/)
-      subject.join
+       .with(/Exception rescued in method:\nRuntimeError: nested outer\n--- Caused by: ---\nRuntimeError: nested inner\n--- Caused by: ---\nArgumentError: boom!/) do |message|
+        expect(message).to_not match(/Thread\.new/)
+      end
+      described_class.rescue_and_log("method", &raise_nested_exception_block)
+    end
+
+    context 'when exception raised that is not derived from StandardError' do
+      let(:block) { raise_script_error_block }
+
+      it 'still rescues and logs' do
+        expect(Listen.logger).to receive(:error).with(/Exception rescued in method:\nScriptError: ruby typo!/)
+        described_class.rescue_and_log("method", &block)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,8 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
+  RSpec::Support::ObjectFormatter.default_instance.max_formatted_output_length = 2_000
+
   config.mock_with :rspec do |mocks|
     mocks.verify_doubled_constant_names = true
     mocks.verify_partial_doubles = true


### PR DESCRIPTION
- Fix for issue #505: If an exception is raised in the `Listen.to` callback to application code, log it and keep running.