### PR TITLE
Issue #510: use monotonic tick count

### DIFF
--- a/lib/listen/adapter/base.rb
+++ b/lib/listen/adapter/base.rb
@@ -93,9 +93,9 @@ module Listen
       end
 
       def _timed(title)
-        start = Time.now.to_f
+        start = MonotonicTime.now
         yield
-        diff = Time.now.to_f - start
+        diff = MonotonicTime.now - start
         Listen.logger.info format('%s: %.05f seconds', title, diff)
       rescue
         Listen.logger.warn "#{title} crashed: #{$ERROR_INFO.inspect}"

--- a/lib/listen/adapter/polling.rb
+++ b/lib/listen/adapter/polling.rb
@@ -21,12 +21,13 @@ module Listen
 
       def _run
         loop do
-          start = Time.now.to_f
+          start = MonotonicTime.now
           @polling_callbacks.each do |callback|
             callback.call(nil)
-            nap_time = options.latency - (Time.now.to_f - start)
-            # TODO: warn if nap_time is negative (polling too slow)
-            sleep(nap_time) if nap_time > 0
+            if (nap_time = options.latency - (MonotonicTime.now - start)) > 0
+              # TODO: warn if nap_time is negative (polling too slow)
+              sleep(nap_time)
+            end
           end
         end
       end

--- a/lib/listen/event/config.rb
+++ b/lib/listen/event/config.rb
@@ -28,10 +28,6 @@ module Listen
         @block&.call(*args)
       end
 
-      def timestamp
-        Time.now.to_f
-      end
-
       def callable?
         @block
       end

--- a/lib/listen/monotonic_time.rb
+++ b/lib/listen/monotonic_time.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Listen
+  module MonotonicTime
+    class << self
+      def now
+        if defined?(Process::CLOCK_MONOTONIC)
+          Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        elsif defined?(Process::CLOCK_MONOTONIC_RAW)
+          Process.clock_gettime(Process::CLOCK_MONOTONIC_RAW)
+        else
+          Time.now.to_f
+        end
+      end
+    end
+  end
+end

--- a/lib/listen/monotonic_time.rb
+++ b/lib/listen/monotonic_time.rb
@@ -3,14 +3,24 @@
 module Listen
   module MonotonicTime
     class << self
-      def now
-        if defined?(Process::CLOCK_MONOTONIC)
+      if defined?(Process::CLOCK_MONOTONIC)
+
+        def now
           Process.clock_gettime(Process::CLOCK_MONOTONIC)
-        elsif defined?(Process::CLOCK_MONOTONIC_RAW)
+        end
+
+      elsif defined?(Process::CLOCK_MONOTONIC_RAW)
+
+        def now
           Process.clock_gettime(Process::CLOCK_MONOTONIC_RAW)
-        else
+        end
+
+      else
+
+        def now
           Time.now.to_f
         end
+
       end
     end
   end

--- a/spec/lib/listen/event/processor_spec.rb
+++ b/spec/lib/listen/event/processor_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Listen::Event::Processor do
   end
 
   let(:state) do
-    { time: 0 }
+    { time: 0.0 }
   end
 
   def status_for_time(time)
@@ -39,7 +39,7 @@ RSpec.describe Listen::Event::Processor do
       status_for_time(state[:time]) == :paused
     end
 
-    allow(config).to receive(:timestamp) do
+    allow(Time).to receive(:now) do
       state[:time]
     end
   end
@@ -67,9 +67,9 @@ RSpec.describe Listen::Event::Processor do
         it 'does not sleep' do
           expect(config).to_not receive(:sleep)
           expect(event_queue).to receive(:pop).and_return(event)
-          t = Time.now.to_f
+          t = Listen::MonotonicTime.now
           subject.loop_for(1)
-          diff = Time.now.to_f - t
+          diff = Listen::MonotonicTime.now - t
           expect(diff).to be < 0.02
         end
       end

--- a/spec/lib/listen/monotonic_time_spec.rb
+++ b/spec/lib/listen/monotonic_time_spec.rb
@@ -5,7 +5,9 @@ require 'listen/monotonic_time'
 RSpec.describe Listen::MonotonicTime do
   context 'module methods' do
     describe '.now' do
+      subject { described_class.now }
       let(:tick_count) { 0.123 }
+
       context 'when CLOCK_MONOTONIC defined' do
         before do
           stub_const('Process::CLOCK_MONOTONIC', 10)
@@ -13,7 +15,7 @@ RSpec.describe Listen::MonotonicTime do
 
         it 'returns the CLOCK_MONOTONIC tick count' do
           expect(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(tick_count)
-          expect(described_class.now).to eq(tick_count)
+          expect(subject).to eq(tick_count)
         end
       end
 
@@ -25,7 +27,7 @@ RSpec.describe Listen::MonotonicTime do
 
         it 'returns the floating point Time.now' do
           expect(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC_RAW).and_return(tick_count)
-          expect(described_class.now).to eq(tick_count)
+          expect(subject).to eq(tick_count)
         end
       end
 
@@ -40,7 +42,7 @@ RSpec.describe Listen::MonotonicTime do
         it 'returns the floating point Time.now' do
           expect(Time).to receive(:now).and_return(now)
           expect(now).to receive(:to_f).and_return(tick_count)
-          expect(described_class.now).to eq(tick_count)
+          expect(subject).to eq(tick_count)
         end
       end
     end

--- a/spec/lib/listen/monotonic_time_spec.rb
+++ b/spec/lib/listen/monotonic_time_spec.rb
@@ -3,6 +3,11 @@
 require 'listen/monotonic_time'
 
 RSpec.describe Listen::MonotonicTime do
+  after(:all) do
+    # load once more with constants unstubbed/unhidden
+    load './lib/listen/monotonic_time.rb'
+  end
+
   context 'module methods' do
     describe '.now' do
       subject { described_class.now }
@@ -11,6 +16,7 @@ RSpec.describe Listen::MonotonicTime do
       context 'when CLOCK_MONOTONIC defined' do
         before do
           stub_const('Process::CLOCK_MONOTONIC', 10)
+          load './lib/listen/monotonic_time.rb'
         end
 
         it 'returns the CLOCK_MONOTONIC tick count' do
@@ -23,6 +29,7 @@ RSpec.describe Listen::MonotonicTime do
         before do
           hide_const('Process::CLOCK_MONOTONIC')
           stub_const('Process::CLOCK_MONOTONIC_RAW', 11)
+          load './lib/listen/monotonic_time.rb'
         end
 
         it 'returns the floating point Time.now' do
@@ -37,6 +44,7 @@ RSpec.describe Listen::MonotonicTime do
         before do
           hide_const('Process::CLOCK_MONOTONIC')
           hide_const('Process::CLOCK_MONOTONIC_RAW')
+          load './lib/listen/monotonic_time.rb'
         end
 
         it 'returns the floating point Time.now' do

--- a/spec/lib/listen/monotonic_time_spec.rb
+++ b/spec/lib/listen/monotonic_time_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'listen/monotonic_time'
+
+RSpec.describe Listen::MonotonicTime do
+  context 'module methods' do
+    describe '.now' do
+      let(:tick_count) { 0.123 }
+      context 'when CLOCK_MONOTONIC defined' do
+        before do
+          stub_const('Process::CLOCK_MONOTONIC', 10)
+        end
+
+        it 'returns the CLOCK_MONOTONIC tick count' do
+          expect(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC).and_return(tick_count)
+          expect(described_class.now).to eq(tick_count)
+        end
+      end
+
+      context 'when CLOCK_MONOTONIC not defined but CLOCK_MONOTONIC_RAW defined' do
+        before do
+          hide_const('Process::CLOCK_MONOTONIC')
+          stub_const('Process::CLOCK_MONOTONIC_RAW', 11)
+        end
+
+        it 'returns the floating point Time.now' do
+          expect(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC_RAW).and_return(tick_count)
+          expect(described_class.now).to eq(tick_count)
+        end
+      end
+
+      context 'when neither CLOCK_MONOTONIC nor CLOCK_MONOTONIC_RAW defined' do
+        let(:now) { instance_double(Time, "time") }
+
+        before do
+          hide_const('Process::CLOCK_MONOTONIC')
+          hide_const('Process::CLOCK_MONOTONIC_RAW')
+        end
+
+        it 'returns the floating point Time.now' do
+          expect(Time).to receive(:now).and_return(now)
+          expect(now).to receive(:to_f).and_return(tick_count)
+          expect(described_class.now).to eq(tick_count)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Addressed issue #510:
- Added `Listen::MonotonicTime` module with `now` method. including tests.
- Change relative time usage to the above.
- Left absolute time (compared with `mtime`) as it was, using `Time.now`.
- Removed unnecessary `timestamp` and `_timestamp` methods.