### PR TITLE
feat: Add rubocop lint github action

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,20 @@
+name: RuboCop
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+        bundler-cache: true
+
+    - name: Run RuboCop
+      run: bundle exec rubocop

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,4 +1,0 @@
-ruby:
-  enabled: true
-  version: 0.91.0
-  config_file: .rubocop.yml


### PR DESCRIPTION
- Remove hound

This PR adds non-annotation based rubocop lint action.
Closes #516 

Currently in draft. Looking for a stable annotation based linting action.