### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/listen.gemspec
+++ b/listen.gemspec
@@ -16,7 +16,13 @@ Gem::Specification.new do |gem|
   gem.description = 'The Listen gem listens to file modifications and '\
     'notifies you about the changes. Works everywhere!'
   gem.metadata = {
-    'allowed_push_host' => 'https://rubygems.org'
+    'allowed_push_host' => 'https://rubygems.org',
+    'bug_tracker_uri' => "#{gem.homepage}/issues",
+    'changelog_uri' => "#{gem.homepage}/releases",
+    'documentation_uri' => "https://www.rubydoc.info/gems/listen/#{gem.version}",
+    'homepage_uri' => gem.homepage,
+    'source_code_uri' => "#{gem.homepage}/tree/v#{gem.version}",
+    'wiki_uri' => "#{gem.homepage}/wiki"
   }
 
   gem.files = `git ls-files -z`.split("\x0").select do |f|


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `homepage_uri`, `source_code_uri`, and `wiki_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/listen), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.