### PR TITLE
Don't return incorrect files when there's a file whose name matches a dir

### DIFF
--- a/lib/listen/record.rb
+++ b/lib/listen/record.rb
@@ -59,13 +59,13 @@ module Listen
 
     def _sub_tree(rel_path)
       @tree.each_with_object({}) do |(path, meta), result|
-        next unless path.start_with?(rel_path)
-
-        if path == rel_path
-          result.merge!(meta)
-        else
-          sub_path         = path.sub(%r{\A#{rel_path}/?}, '')
-          result[sub_path] = meta
+        parts = path.split(::File::SEPARATOR)
+        if parts.shift == rel_path
+          if parts.empty?
+            result.merge!(meta)
+          else
+            result[parts.join(::File::SEPARATOR)] = meta
+          end
         end
       end
     end

--- a/spec/lib/listen/record_spec.rb
+++ b/spec/lib/listen/record_spec.rb
@@ -208,6 +208,29 @@ RSpec.describe Listen::Record do
       end
     end
 
+    context 'when there is a file with the same name as a dir' do
+      subject { record.dir_entries('cypress') }
+
+      before do
+        record.update_file('cypress.json', mtime: 1.1)
+        record.update_file('cypress/README.md', mtime: 1.2)
+        record.update_file('a/b/cypress/d', mtime: 1.3)
+        record.update_file('a/b/c/cypress', mtime: 1.3)
+      end
+      it { should eq('README.md' => { mtime: 1.2 }) }
+    end
+
+    context 'when there is a file with a similar name to a dir' do
+      subject { record.dir_entries('app') }
+
+      before do
+        record.update_file('appspec.yml', mtime: 1.1)
+        record.update_file('app/README.md', mtime: 1.2)
+        record.update_file('spec/app/foo', mtime: 1.3)
+      end
+      it { should eq('README.md' => { mtime: 1.2 }) }
+    end
+
     context 'in subdir /path' do
       subject { record.dir_entries('path') }
 


### PR DESCRIPTION
Fixes a bug in https://github.com/guard/listen/pull/460

We have a file named `cypress.json`, and a dir named `cypress`, in a repo we are watching with `listen`.

Since upgrading to 3.3, `listen` will get confused and report that the file `cypress/.json` was removed. No such file exists.

I'm pretty sure this PR fixes that.