### PR TITLE
Don't return incorrect files when there's a file whose name matches a dir

### DIFF
--- a/lib/listen/record.rb
+++ b/lib/listen/record.rb
@@ -48,7 +48,8 @@ module Listen
       subtree = if [nil, '', '.'].include? rel_path.to_s
         @tree
       else
-        _sub_tree(rel_path)
+        @tree[rel_path.to_s] ||= _auto_hash
+        @tree[rel_path.to_s]
       end
 
       subtree.transform_values do |values|

--- a/lib/listen/record.rb
+++ b/lib/listen/record.rb
@@ -45,7 +45,7 @@ module Listen
     end
 
     def dir_entries(rel_path)
-      subtree = if [nil, '', '.'].include? rel_path.to_s
+      subtree = if ['', '.'].include? rel_path.to_s
         @tree
       else
         @tree[rel_path.to_s] ||= _auto_hash

--- a/lib/listen/record.rb
+++ b/lib/listen/record.rb
@@ -58,19 +58,6 @@ module Listen
       end
     end
 
-    def _sub_tree(rel_path)
-      @tree.each_with_object({}) do |(path, meta), result|
-        next unless path.start_with?(rel_path)
-
-        if path == rel_path
-          result.merge!(meta)
-        else
-          sub_path         = path.sub(%r{\A#{rel_path}/?}, '')
-          result[sub_path] = meta
-        end
-      end
-    end
-
     def build
       @tree = _auto_hash
       # TODO: test with a file name given

--- a/spec/acceptance/listen_spec.rb
+++ b/spec/acceptance/listen_spec.rb
@@ -208,6 +208,29 @@ RSpec.describe 'Listen', acceptance: true do
               end
             end
 
+            context 'listens to sub-subdirectory removed' do
+              around do |example|
+                mkdir_p 'dir1'
+                mkdir_p 'dir1/subdir1'
+                mkdir_p 'dir1/subdir1/subdir2'
+                touch 'dir1/subdir1/file.rb'
+                touch 'dir1/subdir1/subdir2/file.rb'
+                example.run
+              end
+
+              it 'listen to the files of a removed directory' do
+                expected = {
+                  modified: [],
+                  added:    [],
+                  removed:  %w[dir1/subdir1/file.rb dir1/subdir1/subdir2/file.rb]
+                }
+
+                expect(wrapper.listen do
+                  rm_rf 'dir1/subdir1'
+                end).to eq expected
+              end
+            end
+
             context 'with .bundle dir ignored by default' do
               around do |example|
                 mkdir_p '.bundle'

--- a/spec/lib/listen/record_spec.rb
+++ b/spec/lib/listen/record_spec.rb
@@ -208,6 +208,29 @@ RSpec.describe Listen::Record do
       end
     end
 
+    context 'when there is a file with the same name as a dir' do
+      subject { record.dir_entries('cypress') }
+
+      before do
+        record.update_file('cypress.json', mtime: 1.1)
+        record.update_file('cypress/README.md', mtime: 1.2)
+        record.update_file('a/b/cypress/d', mtime: 1.3)
+        record.update_file('a/b/c/cypress', mtime: 1.3)
+      end
+      it { should eq('README.md' => { mtime: 1.2 }) }
+    end
+
+    context 'when there is a file with a similar name to a dir' do
+      subject { record.dir_entries('app') }
+
+      before do
+        record.update_file('appspec.yml', mtime: 1.1)
+        record.update_file('app/README.md', mtime: 1.2)
+        record.update_file('spec/app/foo', mtime: 1.3)
+      end
+      it { should eq('README.md' => { mtime: 1.2 }) }
+    end
+
     context 'in subdir /path' do
       subject { record.dir_entries('path') }
 
@@ -220,9 +243,17 @@ RSpec.describe Listen::Record do
         it { should eq('file.rb' => { mtime: 1.1 }) }
       end
 
-      context 'with path/subdir' do
+      context 'with empty path/subdir' do
         before { record.add_dir('path/subdir') }
-        it { should eq('subdir' => {}) }
+        it { should be_empty }
+      end
+
+      context 'with path/subdir with file' do
+        before do
+          record.add_dir('path/subdir')
+          record.update_file('path/subdir/file.rb', mtime: 1.1)
+        end
+        it { should be_empty }
       end
     end
   end


### PR DESCRIPTION
Simpler attempt at https://github.com/guard/listen/pull/524. Reverts https://github.com/guard/listen/pull/460.

Even with the changes in https://github.com/guard/listen/pull/460 reversed, the acceptance tests still pass. Only one unit test fails, and I'm not sure it's asserting the right behavior. With this approach, the new tests in https://github.com/guard/listen/pull/524 also still pass.

cc @bryanlira @ColinDKelley 