### PR TITLE
added correct link to help debug inotify workers error on linux

### DIFF
--- a/lib/listen/adapter/linux.rb
+++ b/lib/listen/adapter/linux.rb
@@ -21,8 +21,9 @@ module Listen
 
       private
 
+      
       WIKI_URL = 'https://github.com/guard/listen'\
-        '/wiki/Increasing-the-amount-of-inotify-watchers'
+        '/blob/master/README.md#increasing-the-amount-of-inotify-watchers'
 
       INOTIFY_LIMIT_MESSAGE = <<-EOS.gsub(/^\s*/, '')
         FATAL: Listen error: unable to monitor directories for changes.

--- a/lib/listen/adapter/linux.rb
+++ b/lib/listen/adapter/linux.rb
@@ -21,7 +21,6 @@ module Listen
 
       private
 
-      
       WIKI_URL = 'https://github.com/guard/listen'\
         '/blob/master/README.md#increasing-the-amount-of-inotify-watchers'
 


### PR DESCRIPTION
Pretty straightforward change. 

On my CI build, the INOTIFY_LIMIT_MESSAGE was being displayed but the link was taking me to the wrong place. 

It had me scratching my head for a few seconds until I read the readme. 

Hope it helps. 