### PR TITLE
Add tests for PR #529

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contribute to Listen
 File an issue
 -------------
 
-If you haven't already, first see [TROUBLESHOOTING](https://github.com/guard/listen/wiki/Troubleshooting) for known issues, solutions and workarounds.
+If you haven't already, first see [TROUBLESHOOTING](https://github.com/guard/listen/blob/master/README.md#Issues-and-Troubleshooting) for known issues, solutions and workarounds.
 
 You can report bugs and feature requests to [GitHub Issues](https://github.com/guard/listen/issues).
 
@@ -16,7 +16,7 @@ Try to figure out where the issue belongs to: Is it an issue with Listen itself 
 
 **It's most likely that your bug gets resolved faster if you provide as much information as possible!**
 
-The MOST useful information is debugging output from Listen (`LISTEN_GEM_DEBUGGING=1`) - see [TROUBLESHOOTING](https://github.com/guard/listen/wiki/Troubleshooting) for details.
+The MOST useful information is debugging output from Listen (`LISTEN_GEM_DEBUGGING=1`) - see [TROUBLESHOOTING](https://github.com/guard/listen/blob/master/README.md#Issues-and-Troubleshooting) for details.
 
 
 Development

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 The `listen` gem listens to file modifications and notifies you about the changes.
 
-:exclamation: `Listen` is currently accepting more maintainers. Please [read this](https://github.com/guard/guard/wiki/Maintainers) if you're interested in joining the team.
-
 [![Development Status](https://github.com/guard/listen/workflows/Development/badge.svg)](https://github.com/guard/listen/actions?workflow=Development)
 [![Gem Version](https://badge.fury.io/rb/listen.svg)](http://badge.fury.io/rb/listen)
 [![Code Climate](https://codeclimate.com/github/guard/listen.svg)](https://codeclimate.com/github/guard/listen)

--- a/lib/listen/adapter/linux.rb
+++ b/lib/listen/adapter/linux.rb
@@ -21,12 +21,12 @@ module Listen
 
       private
 
-      WIKI_URL = 'https://github.com/guard/listen'\
+      README_URL = 'https://github.com/guard/listen'\
         '/blob/master/README.md#increasing-the-amount-of-inotify-watchers'
 
-      INOTIFY_LIMIT_MESSAGE = <<-EOS.gsub(/^\s*/, '')
+      INOTIFY_LIMIT_MESSAGE = <<-EOS
         FATAL: Listen error: unable to monitor directories for changes.
-        Visit #{WIKI_URL} for info on how to fix this.
+        Visit #{README_URL} for info on how to fix this.
       EOS
 
       def _configure(directory, &callback)

--- a/lib/listen/error.rb
+++ b/lib/listen/error.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+# Besides programming error exceptions like ArgumentError,
+# all public interface exceptions should be declared here and inherit from Listen::Error.
 module Listen
   class Error < RuntimeError
     class NotStarted < Error; end
+    class SymlinkLoop < Error; end
   end
 end

--- a/lib/listen/error.rb
+++ b/lib/listen/error.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Listen
+  class Error < RuntimeError
+    class NotStarted < Error; end
+  end
+end

--- a/lib/listen/event/loop.rb
+++ b/lib/listen/event/loop.rb
@@ -12,7 +12,7 @@ module Listen
     class Loop
       include Listen::FSM
 
-      class Error < RuntimeError
+      module Error
         NotStarted = ::Listen::Error::NotStarted # for backward compatibility
       end
 

--- a/lib/listen/event/loop.rb
+++ b/lib/listen/event/loop.rb
@@ -12,9 +12,8 @@ module Listen
     class Loop
       include Listen::FSM
 
-      module Error
-        NotStarted = ::Listen::Error::NotStarted # for backward compatibility
-      end
+      Error = ::Listen::Error
+      NotStarted = ::Listen::Error::NotStarted # for backward compatibility
 
       start_state :pre_start
       state :pre_start

--- a/lib/listen/event/loop.rb
+++ b/lib/listen/event/loop.rb
@@ -5,6 +5,7 @@ require 'thread'
 require 'timeout'
 require 'listen/event/processor'
 require 'listen/thread'
+require 'listen/error'
 
 module Listen
   module Event
@@ -12,7 +13,7 @@ module Listen
       include Listen::FSM
 
       class Error < RuntimeError
-        class NotStarted < Error; end
+        NotStarted = ::Listen::Error::NotStarted # for backward compatibility
       end
 
       start_state :pre_start
@@ -40,6 +41,7 @@ module Listen
 
       MAX_STARTUP_SECONDS = 5.0
 
+      # @raises Error::NotStarted if background thread hasn't started in MAX_STARTUP_SECONDS
       def start
         # TODO: use a Fiber instead?
         return unless state == :pre_start

--- a/lib/listen/fsm.rb
+++ b/lib/listen/fsm.rb
@@ -53,6 +53,9 @@ module Listen
     # if not already, waits for a state change (up to timeout seconds--`nil` means infinite)
     # returns truthy iff the transition to one of the desired state has occurred
     def wait_for_state(*wait_for_states, timeout: nil)
+      wait_for_states.each do |state|
+        state.is_a?(Symbol) or raise ArgumentError, "states must be symbols (got #{state.inspect})"
+      end
       @mutex.synchronize do
         if !wait_for_states.include?(@state)
           @state_changed.wait(@mutex, timeout)

--- a/lib/listen/record/symlink_detector.rb
+++ b/lib/listen/record/symlink_detector.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'set'
+require 'listen/error'
 
 module Listen
   # @private api
@@ -18,8 +19,7 @@ module Listen
         MORE INFO: #{WIKI}
       EOS
 
-      class Error < RuntimeError
-      end
+      Error = ::Listen::Error # for backward compatibility
 
       def initialize
         @real_dirs = Set.new
@@ -27,14 +27,14 @@ module Listen
 
       def verify_unwatched!(entry)
         real_path = entry.real_path
-        @real_dirs.add?(real_path) || _fail(entry.sys_path, real_path)
+        @real_dirs.add?(real_path) or _fail(entry.sys_path, real_path)
       end
 
       private
 
       def _fail(symlinked, real_path)
         warn(format(SYMLINK_LOOP_ERROR, symlinked, real_path))
-        raise Error, 'Failed due to looped symlinks'
+        raise ::Listen::Error::SymlinkLoop, 'Failed due to looped symlinks'
       end
     end
   end

--- a/lib/listen/record/symlink_detector.rb
+++ b/lib/listen/record/symlink_detector.rb
@@ -7,7 +7,7 @@ module Listen
   # @private api
   class Record
     class SymlinkDetector
-      WIKI = 'https://github.com/guard/listen/wiki/Duplicate-directory-errors'
+      README_URL = 'https://github.com/guard/listen/blob/master/README.md'
 
       SYMLINK_LOOP_ERROR = <<-EOS
         ** ERROR: directory is already being watched! **
@@ -16,7 +16,7 @@ module Listen
 
         is already being watched through: %s
 
-        MORE INFO: #{WIKI}
+        MORE INFO: #{README_URL}
       EOS
 
       Error = ::Listen::Error # for backward compatibility

--- a/listen.gemspec
+++ b/listen.gemspec
@@ -21,8 +21,7 @@ Gem::Specification.new do |gem|
     'changelog_uri' => "#{gem.homepage}/releases",
     'documentation_uri' => "https://www.rubydoc.info/gems/listen/#{gem.version}",
     'homepage_uri' => gem.homepage,
-    'source_code_uri' => "#{gem.homepage}/tree/v#{gem.version}",
-    'wiki_uri' => "#{gem.homepage}/wiki"
+    'source_code_uri' => "#{gem.homepage}/tree/v#{gem.version}"
   }
 
   gem.files = `git ls-files -z`.split("\x0").select do |f|


### PR DESCRIPTION
Builds on PR #529 :
- Adds missing tests to `fsm_spec` (ensure state names are symbols in `wait_for_state`) and `loop_spec` (raise exception if not started in 5 seconds).
- Moves `Error` down to a common `Listen::Error` base class.
- Removes stray references to the wiki since we have switched over to the README.