### PR TITLE
Don't log SystemExit as an error

### DIFF
--- a/lib/listen/thread.rb
+++ b/lib/listen/thread.rb
@@ -31,6 +31,8 @@ module Listen
       private
 
       def _log_exception(exception, thread_name, caller_stack: nil)
+        return if exception.is_a? SystemExit
+
         complete_backtrace = if caller_stack
           [*exception.backtrace, "--- Thread.new ---", *caller_stack]
         else


### PR DESCRIPTION
Using Guard with listen, when Guard is notified by listen that the `Guardfile` changed, Guard calls `exit`.

This results in the following alarming output:

```
E, [2021-03-09T10:48:09.258474 #79158] ERROR -- : Exception rescued in _process_changes:
SystemExit: exit
/opt/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/guard-2.16.2/lib/guard.rb:166:in `exit'
/opt/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/guard-2.16.2/lib/guard.rb:166:in `_guardfile_deprecated_check'
/opt/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/guard-2.16.2/lib/guard.rb:121:in `block in _listener_callback'
/opt/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/listen-3.4.1/lib/listen/event/config.rb:28:in `call'
/opt/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/listen-3.4.1/lib/listen/event/processor.rb:117:in `block in _process_changes'
/opt/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/listen-3.4.1/lib/listen/thread.rb:26:in `rescue_and_log'
/opt/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/listen-3.4.1/lib/listen/event/processor.rb:116:in `_process_changes'
/opt/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/listen-3.4.1/lib/listen/event/processor.rb:25:in `block in loop_for'
/opt/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/listen-3.4.1/lib/listen/event/processor.rb:20:in `loop'
/opt/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/listen-3.4.1/lib/listen/event/processor.rb:20:in `loop_for'
/opt/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/listen-3.4.1/lib/listen/event/loop.rb:85:in `_process_changes'
/opt/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/listen-3.4.1/lib/listen/event/loop.rb:51:in `block in start'
/opt/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/listen-3.4.1/lib/listen/thread.rb:26:in `rescue_and_log'
/opt/rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/listen-3.4.1/lib/listen/thread.rb:18:in `block in new'
```

This seems intended to indicate a failure state, but a `SystemExit` is not a failure.
