### PR TITLE
Bump required ruby version to v2.4.0

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -6,21 +6,22 @@ jobs:
   test:
     runs-on: ${{matrix.os}}-latest
     continue-on-error: ${{matrix.experimental}}
-    
+
     strategy:
       matrix:
         os:
           - ubuntu
           - macos
-        
+
         ruby:
+          - 2.4
           - 2.5
           - 2.6
           - 2.7
-        
+
         experimental: [false]
         env: [""]
-        
+
         include:
           - os: macos
             ruby: truffleruby-head
@@ -34,14 +35,14 @@ jobs:
           - os: ubuntu
             ruby: head
             experimental: true
-    
+
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{matrix.ruby}}
         bundler-cache: true
-    
+
     - name: Run tests
       timeout-minutes: 6
       run: |

--- a/listen.gemspec
+++ b/listen.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
   gem.executable   = 'listen'
   gem.require_path = 'lib'
 
-  gem.required_ruby_version = '>= 2.2.7' # rubocop:disable Gemspec/RequiredRubyVersion
+  gem.required_ruby_version = '>= 2.4.0' # rubocop:disable Gemspec/RequiredRubyVersion
 
   gem.add_dependency 'rb-fsevent', '~> 0.10', '>= 0.10.3'
   gem.add_dependency 'rb-inotify', '~> 0.9', '>= 0.9.10'


### PR DESCRIPTION
a9137acc introduced a use of `Hash#transform_values` in `Listen::Record#dir_entries`, however that was only added to Ruby in [v2.4](https://github.com/ruby/ruby/blob/v2_4_0/NEWS#core-classes-updates-outstanding-ones-only-).

This can lead to runtime errors when run on an older version of Ruby, such as 2.2.7, which the gemspec previously implied was supported.

It looks like CI only runs on Ruby 2.5+, so an argument could also be made the gemspec should follow suit:
https://github.com/guard/listen/blob/c00a57bffa057c520c5b7285420c21e3aff11454/.github/workflows/development.yml#L17-L19

Bumping to v2.4 was the simplest to resolve the immediate problem I was facing running an old project on Ruby v2.3.4 while I work to upgrade it.