### PR TITLE
BSD: Don't send ignored paths to kqueue

### DIFF
--- a/lib/listen/adapter/bsd.rb
+++ b/lib/listen/adapter/bsd.rb
@@ -45,7 +45,11 @@ module Listen
         @callback = callback
         # use Record to make a snapshot of dir, so we
         # can detect new files
-        _find(directory.to_s) { |path| _watch_file(path, @worker) }
+        _find(directory.to_s) do |path|
+          unless @config.silencer.silenced?(Pathname.new(path).relative_path_from(directory), FileTest.directory?(path) ? :dir : :file)
+            _watch_file(path, @worker)
+          end
+        end
       end
 
       def _run


### PR DESCRIPTION
I'm using this via Jekyll's `--watch` option and on OpenBSD I either have to get a CPU-eating poll of its giant directory structure (because of `.git` and `vendor/bundle`) or I use `rb-kqueue` and the process quickly dies after running out of file handles.

Since the paths being ignored by the Silencer aren't used anyway, can it just not pass them to kqueue and avoid watching them?