### PR TITLE
issue #452: use SHA256 instead of MD5 for FIPS compatibility

### DIFF
--- a/lib/listen/file.rb
+++ b/lib/listen/file.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'digest/md5'
+require 'digest'
 
 module Listen
   class File
@@ -53,7 +53,7 @@ module Listen
       # then at ???14.998, but the fstat time would be ???14.0 in
       # both cases).
       #
-      # If change happend at ???14.999997, the mtime is 14.0, so for
+      # If change happened at ???14.999997, the mtime is 14.0, so for
       # an mtime=???14.0 we assume it could even be almost ???15.0
       #
       # So if Time.now.to_f is ???15.999998 and stat reports mtime
@@ -67,9 +67,11 @@ module Listen
       #
       return if data[:mtime].to_i + 2 <= Time.now.to_f
 
-      md5 = Digest::MD5.file(path).digest
-      record.update_file(rel_path, data.merge(md5: md5))
-      :modified if record_data[:md5] && md5 != record_data[:md5]
+      sha = Digest::SHA256.file(path).digest
+      record.update_file(rel_path, data.merge(sha: sha))
+      if record_data[:sha] && sha != record_data[:sha]
+        :modified
+      end
     rescue SystemCallError
       record.unset_path(rel_path)
       :removed

--- a/spec/lib/listen/file_spec.rb
+++ b/spec/lib/listen/file_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe Listen::File do
 
     context 'with file record' do
       let(:record_mtime) { nil }
-      let(:record_md5) { nil }
+      let(:record_sha) { nil }
       let(:record_mode) { nil }
       let(:record_size) { nil }
 
       let(:record_data) do
-        { mtime: record_mtime, md5: record_md5, mode: record_mode, size: record_size }
+        { mtime: record_mtime, sha: record_sha, mode: record_mode, size: record_size }
       end
 
       context 'with non-existing file' do
@@ -54,7 +54,7 @@ RSpec.describe Listen::File do
         let(:record_size) { 42 }
         let(:stat_size) { record_size }
 
-        let(:md5) { fail 'stub me (md5)' }
+        let(:sha) { fail 'stub me (sha)' }
 
         let(:stat) do
           instance_double(
@@ -69,7 +69,7 @@ RSpec.describe Listen::File do
 
         before do
           allow(::File).to receive(:lstat) { stat }
-          allow(Digest::MD5).to receive(:file) { double(:md5, digest: md5) }
+          allow(Digest::SHA256).to receive(:file) { double(:sha, digest: sha) }
         end
 
         context 'with different mode in record' do
@@ -148,8 +148,8 @@ RSpec.describe Listen::File do
 
                 before { allow(Time).to receive(:now) { now } }
 
-                context 'without available md5' do
-                  let(:md5) { fail Errno::ENOENT }
+                context 'without available sha' do
+                  let(:sha) { fail Errno::ENOENT }
 
                   # Treat it as a removed file, because chances are ...
                   # whatever is listening for changes won't be able to deal
@@ -161,25 +161,25 @@ RSpec.describe Listen::File do
                   end
                 end
 
-                context 'with available md5' do
-                  let(:md5) { 'd41d8cd98f00b204e9800998ecf8427e' }
+                context 'with available sha' do
+                  let(:sha) { 'd41d8cd98f00b204e9800998ecf8427e' }
 
-                  context 'with same md5 in record' do
-                    let(:record_md5) { md5 }
+                  context 'with same sha in record' do
+                    let(:record_sha) { sha }
                     it { should be_nil }
                   end
 
-                  context 'with no md5 in record' do
-                    let(:record_md5) { nil }
+                  context 'with no sha in record' do
+                    let(:record_sha) { nil }
                     it { should be_nil }
                   end
 
-                  context 'with different md5 in record' do
-                    let(:record_md5) { 'foo' }
+                  context 'with different sha in record' do
+                    let(:record_sha) { 'foo' }
                     it { should be :modified }
 
                     it 'sets path in record with expected data' do
-                      expected = expected_data.merge(md5: md5)
+                      expected = expected_data.merge(sha: sha)
                       expect(record).to receive(:update_file).
                         with('file.rb', expected)
                       subject

--- a/spec/support/acceptance_helper.rb
+++ b/spec/support/acceptance_helper.rb
@@ -74,7 +74,7 @@ end
 # notification happens a little while later, e.g. at 1234568.111, now the file
 # mtime and the current time in seconds are different (1234567 vs 1234568), and
 # so the MD5 test won't kick in (see file.rb) - the file will not be considered
-# for content checking (md5), so File.change will consider the file unmodified.
+# for content checking (sha), so File.change will consider the file unmodified.
 #
 # This means, that if a file is added at 1234567.888 (and updated in Record),
 # and then its content is modified at 1234567.999, and checking for changes


### PR DESCRIPTION
Addresses issue #452 by using SHA256 instead of MD5.