### PR TITLE
fix: Avoid scanning and building entries for silenced directories

### DIFF
--- a/lib/listen/adapter/base.rb
+++ b/lib/listen/adapter/base.rb
@@ -51,7 +51,7 @@ module Listen
         # TODO: separate config per directory (some day maybe)
         change_config = Change::Config.new(config.queue, config.silencer)
         config.directories.each do |dir|
-          record = Record.new(dir)
+          record = Record.new(dir, config.silencer)
           snapshot = Change.new(change_config, record)
           @snapshots[dir] = snapshot
         end

--- a/lib/listen/record.rb
+++ b/lib/listen/record.rb
@@ -11,9 +11,10 @@ module Listen
 
     attr_reader :root
 
-    def initialize(directory)
+    def initialize(directory, silencer)
       @tree = _auto_hash
       @root = directory.to_s
+      @silencer = silencer
     end
 
     def add_dir(rel_path)
@@ -98,6 +99,8 @@ module Listen
 
     def _fast_build_dir(remaining, symlink_detector)
       entry = remaining.pop
+      return if @silencer.silenced?(entry.record_dir_key, :dir)
+
       children = entry.children # NOTE: children() implicitly tests if dir
       symlink_detector.verify_unwatched!(entry)
       children.each { |child| remaining << child }

--- a/spec/lib/listen/record_spec.rb
+++ b/spec/lib/listen/record_spec.rb
@@ -2,7 +2,8 @@
 
 RSpec.describe Listen::Record do
   let(:dir) { instance_double(Pathname, to_s: '/dir') }
-  let(:record) { Listen::Record.new(dir) }
+  let(:silencer) { Listen::Silencer.new }
+  let(:record) { Listen::Record.new(dir, silencer) }
 
   def dir_entries_for(hash)
     hash.each do |dir, entries|
@@ -308,9 +309,11 @@ RSpec.describe Listen::Record do
 
     context 'with subdir containing files' do
       before do
-        real_directory('/dir' => %w[dir1 dir2])
+        real_directory('/dir' => %w[dir1 dir2 .git])
+        real_directory('/dir/.git' => %w[FETCH_HEAD])
         real_directory('/dir/dir1' => %w[foo])
         real_directory('/dir/dir1/foo' => %w[bar])
+        lstat(file('/dir/.git/FETCH_HEAD'))
         lstat(file('/dir/dir1/foo/bar'))
         real_directory('/dir/dir2' => [])
       end


### PR DESCRIPTION
### Description 📖 

This pull request patches the `Record#build` method to avoid recursively scanning and creating entries for directories that are being ignored in the `Listener` configuration.

### Background 📜 

Building entries that will be ignored by the listener degrades the initialization performance, and can greatly increase memory consumption.

This is especially noticeable on projects with large `.git` or `node_modules` directories.

### The Fix 🔨 

Use the `Silencer` configuration to avoid scanning ignored directories.

### Benchmarks 📈 

The performance difference is significant on startup time.

Using the `listen` gem in a [small Jekyll site](https://github.com/ElMassimo/jekyll-vite/tree/main/docs):

#### Before (silenced dirs are scanned)
```
Record.build(): 0.70397 seconds
```

#### After (silenced dirs are ignored)
```
Record.build(): 0.02439 seconds
```

### Additional Benefits ✨ 

Directories that are ignored would no longer output symlink warnings since they are no longer being scanned.