### PR TITLE
Plumb Silencer.new and use it #542 spec

### DIFF
--- a/lib/listen/silencer.rb
+++ b/lib/listen/silencer.rb
@@ -57,23 +57,21 @@ module Listen
       | ~
     )$}x.freeze
 
+    # TODO: deprecate these mutators; use attr_reader instead
     attr_accessor :only_patterns, :ignore_patterns
 
-    def initialize
-      configure({})
+    def initialize(options = {})
+      configure(options)
     end
 
+    # TODO: deprecate this mutator
     def configure(options)
       @only_patterns = options[:only] ? Array(options[:only]) : nil
       @ignore_patterns = _init_ignores(options[:ignore], options[:ignore!])
     end
 
-    # Note: relative_path is temporarily expected to be a relative Pathname to
-    # make refactoring easier (ideally, it would take a string)
-
-    # TODO: switch type and path places - and verify
     def silenced?(relative_path, type)
-      path = relative_path.to_s
+      path = relative_path.to_s   # in case it is a Pathname
 
       _ignore?(path) || (only_patterns && type == :file && !_only?(path))
     end

--- a/spec/lib/listen/adapter/base_spec.rb
+++ b/spec/lib/listen/adapter/base_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Listen::Adapter::Base do
     end
 
     # Stuff that happens in configure()
-    allow(Listen::Record).to receive(:new).with(dir1).and_return(record)
+    allow(Listen::Record).to receive(:new).with(dir1, silencer).and_return(record)
 
     allow(Listen::Change::Config).to receive(:new).with(queue, silencer).
       and_return(config)

--- a/spec/lib/listen/adapter/linux_spec.rb
+++ b/spec/lib/listen/adapter/linux_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Listen::Adapter::Linux do
           allow(config).to receive(:adapter_options).and_return(adapter_options)
           allow(config).to receive(:silencer).and_return(silencer)
 
-          allow(Listen::Record).to receive(:new).with(dir1).and_return(record)
+          allow(Listen::Record).to receive(:new).with(dir1, silencer).and_return(record)
           allow(Listen::Change::Config).to receive(:new).with(queue, silencer).
             and_return(config)
           allow(Listen::Change).to receive(:new).with(config, record).

--- a/spec/lib/listen/adapter/polling_spec.rb
+++ b/spec/lib/listen/adapter/polling_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Adapter::Polling do
       allow(config).to receive(:queue).and_return(queue)
       allow(config).to receive(:silencer).and_return(silencer)
 
-      allow(Listen::Record).to receive(:new).with(dir1).and_return(record)
+      allow(Listen::Record).to receive(:new).with(dir1, silencer).and_return(record)
 
       allow(Listen::Change).to receive(:new).with(config, record).
         and_return(snapshot)

--- a/spec/lib/listen/silencer_spec.rb
+++ b/spec/lib/listen/silencer_spec.rb
@@ -6,7 +6,7 @@ end
 
 RSpec.describe Listen::Silencer do
   let(:options) { {} }
-  before { subject.configure(options) }
+  subject { described_class.new(options) }
 
   describe '#silenced?' do
     it { should accept(:file, Pathname('some_dir').join("some_file.rb")) }


### PR DESCRIPTION
- Use explicit ` ignore!: [/\A\.ignored/]` silencer option in `record_spec` so we're not depending on `Silencer`'s defaults.
- Update `Silencer` to allow its config to be passed into `initialize` rather than mutated by `configure`. Update some comments there about deprecating mutation.
- Update a few stubs that no longer matched.