### PR TITLE
issue #509: raise Listen::Error::INotifyMaxWatchesExceeded rather than abort

### DIFF
--- a/lib/listen/adapter/linux.rb
+++ b/lib/listen/adapter/linux.rb
@@ -24,17 +24,15 @@ module Listen
       README_URL = 'https://github.com/guard/listen'\
         '/blob/master/README.md#increasing-the-amount-of-inotify-watchers'
 
-      INOTIFY_LIMIT_MESSAGE = <<-EOS
-        FATAL: Listen error: unable to monitor directories for changes.
-        Visit #{README_URL} for info on how to fix this.
-      EOS
-
       def _configure(directory, &callback)
         require 'rb-inotify'
         @worker ||= ::INotify::Notifier.new
         @worker.watch(directory.to_s, *options.events, &callback)
       rescue Errno::ENOSPC
-        abort(INOTIFY_LIMIT_MESSAGE)
+        raise ::Listen::Error::INotifyMaxWatchesExceeded, <<~EOS
+          FATAL: Listen error: Unable to monitor directories for changes because iNotify max watches exceeded.
+          Visit #{README_URL} for info on how to fix this.
+        EOS
       end
 
       def _run

--- a/lib/listen/adapter/linux.rb
+++ b/lib/listen/adapter/linux.rb
@@ -30,8 +30,7 @@ module Listen
         @worker.watch(directory.to_s, *options.events, &callback)
       rescue Errno::ENOSPC
         raise ::Listen::Error::INotifyMaxWatchesExceeded, <<~EOS
-          FATAL: Listen error: Unable to monitor directories for changes because iNotify max watches exceeded.
-          Visit #{README_URL} for info on how to fix this.
+          Unable to monitor directories for changes because iNotify max watches exceeded. See #{README_URL} .
         EOS
       end
 

--- a/lib/listen/error.rb
+++ b/lib/listen/error.rb
@@ -6,5 +6,6 @@ module Listen
   class Error < RuntimeError
     class NotStarted < Error; end
     class SymlinkLoop < Error; end
+    class INotifyMaxWatchesExceeded < Error; end
   end
 end

--- a/spec/lib/listen/adapter/linux_spec.rb
+++ b/spec/lib/listen/adapter/linux_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Listen::Adapter::Linux do
         end
       end
 
-      describe 'inotify limit message' do
+      describe 'inotify max watches exceeded' do
         let(:directories) { [Pathname.pwd] }
         let(:adapter_options) { {} }
 
@@ -74,9 +74,8 @@ RSpec.describe Listen::Adapter::Linux do
           allow(config).to receive(:adapter_options).and_return(adapter_options)
         end
 
-        it 'should be shown before calling abort' do
-          expected_message = described_class.const_get('INOTIFY_LIMIT_MESSAGE')
-          expect { subject.start }.to raise_error SystemExit, expected_message
+        it 'raises exception' do
+          expect { subject.start }.to raise_exception(Listen::Error::INotifyMaxWatchesExceeded, /inotify max watches exceeded/i)
         end
       end
 


### PR DESCRIPTION
Fix for issue #509:
- When iNotify max watchers exceeded, raise `INotifyMaxWatchesExceeded` rather than abort.