### PR TITLE
Ignore emacs backup/swap files by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ listener.stop    # stop both listening to changes and processing them
 
 ### Ignore / ignore!
 
-`Listen` ignores some directories and extensions by default (See DEFAULT_IGNORED_DIRECTORIES and DEFAULT_IGNORED_EXTENSIONS in Listen::Silencer).
+`Listen` ignores some directories and extensions by default (See DEFAULT_IGNORED_FILES and DEFAULT_IGNORED_EXTENSIONS in Listen::Silencer).
 You can add ignoring patterns with the `ignore` option/method or overwrite default with `ignore!` option/method.
 
 ``` ruby
@@ -157,7 +157,7 @@ All the following options can be set through the `Listen.to` after the directory
 
 ```ruby
 ignore: [%r{/foo/bar}, /\.pid$/, /\.coffee$/]   # Ignore a list of paths
-                                                # default: See DEFAULT_IGNORED_DIRECTORIES and DEFAULT_IGNORED_EXTENSIONS in Listen::Silencer
+                                                # default: See DEFAULT_IGNORED_FILES and DEFAULT_IGNORED_EXTENSIONS in Listen::Silencer
 
 ignore!: %r{/foo/bar}                           # Same as ignore options, but overwrite default ignored paths.
 

--- a/lib/listen/silencer.rb
+++ b/lib/listen/silencer.rb
@@ -3,8 +3,8 @@
 module Listen
   class Silencer
     # The default list of directories that get ignored.
-    DEFAULT_IGNORED_DIRECTORIES = %r{^(?:
-      \.git
+    DEFAULT_IGNORED_FILES = %r{\A(?:
+    \.git
       | \.svn
       | \.hg
       | \.rbx
@@ -13,8 +13,12 @@ module Listen
       | vendor/bundle
       | log
       | tmp
-      |vendor/ruby
-    )(/|$)}x.freeze
+      | vendor/ruby
+
+      # emacs temp files
+      | \#.+\#
+      | \.\#.+
+      )(/|\z)}x.freeze
 
     # The default list of files that get ignored.
     DEFAULT_IGNORED_EXTENSIONS = %r{(?:
@@ -34,11 +38,8 @@ module Listen
       | \.swpx
       | ^4913
 
-      # Emacs backup/swap files
-      | (?:\.\#.+|\#.+\#)
-
       # Sed temporary files - but without actual words, like 'sedatives'
-      | (?:^
+      | (?:\A
          sed
 
          (?:
@@ -58,7 +59,7 @@ module Listen
       | \.DS_Store
       | \.tmp
       | ~
-    )$}x.freeze
+    )\z}x.freeze
 
     # TODO: deprecate these mutators; use attr_reader instead
     attr_accessor :only_patterns, :ignore_patterns
@@ -92,7 +93,7 @@ module Listen
     def _init_ignores(ignores, overrides)
       patterns = []
       unless overrides
-        patterns << DEFAULT_IGNORED_DIRECTORIES
+        patterns << DEFAULT_IGNORED_FILES
         patterns << DEFAULT_IGNORED_EXTENSIONS
       end
 

--- a/lib/listen/silencer.rb
+++ b/lib/listen/silencer.rb
@@ -34,6 +34,9 @@ module Listen
       | \.swpx
       | ^4913
 
+      # Emacs backup/swap files
+      | (?:\.\#.+|\#.+\#)
+
       # Sed temporary files - but without actual words, like 'sedatives'
       | (?:^
          sed

--- a/spec/lib/listen/silencer_spec.rb
+++ b/spec/lib/listen/silencer_spec.rb
@@ -34,6 +34,9 @@ RSpec.describe Listen::Silencer do
       # Vim swap files
       ignored += %w[foo.swp foo.swx foo.swpx 4913]
 
+      # Emacs backup/swap files
+      ignored += %w[#hello.rb# .#hello.rb]
+
       # sed temp files
       ignored += %w[sedq7eVAR sed86w1kB]
 


### PR DESCRIPTION
For fix #543 