### PR TITLE
Add Ruby 3.0/3.1 to CI

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -18,6 +18,8 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
+          - "3.0" # need quotes for "3.0"
+          - 3.1
 
         experimental: [false]
         env: [""]


### PR DESCRIPTION
This change just adds Ruby [3.0](https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/) and [3.1](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/) to the CI matrix.
