### PR TITLE
Disable fail-fast for CI matrix

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -8,6 +8,7 @@ jobs:
     continue-on-error: ${{matrix.experimental}}
 
     strategy:
+      fail-fast: false
       matrix:
         os:
           - ubuntu


### PR DESCRIPTION
This change aims to prevent canceling running jobs if some jobs fail.

See also:
- [Workflow syntax for GitHub Actions - GitHub Docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast)
- [How-to Github Actions: Build Matrix - Nicola Corti](https://ncorti.com/blog/howto-github-actions-build-matrix)