### PR TITLE
Rubocop workflow with GitHub actions

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -49,3 +49,18 @@ jobs:
       timeout-minutes: 6
       run: |
         ${{matrix.env}} bundle exec rspec
+
+  linting:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.2
+        bundler-cache: true
+
+    - name: Run rubocop
+      timeout-minutes: 6
+      run: |
+        bundle exec rake rubocop

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,4 +1,0 @@
-ruby:
-  enabled: true
-  version: 0.91.0
-  config_file: .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -200,6 +200,8 @@ Style/KeywordParametersOrder:
   Enabled: true
 Style/Lambda:
   Enabled: false
+Style/MixinUsage:
+  Enabled: false
 Style/ModuleFunction:
   Enabled: false
 Style/NegatedIf:

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,6 @@ group :development do
   gem 'netrc', require: false
   gem 'octokit', require: false
   gem 'pry-rescue'
-  gem 'rubocop', '0.91.0'
+  gem 'rubocop'
   gem 'yard', require: false
 end

--- a/Rakefile
+++ b/Rakefile
@@ -5,13 +5,9 @@ require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-if ENV["CI"] != "true"
   require "rubocop/rake_task"
   RuboCop::RakeTask.new(:rubocop)
   task default: [:spec, :rubocop]
-else
-  task default: [:spec]
-end
 
 class Releaser
   def initialize(options = {})

--- a/lib/listen/adapter/bsd.rb
+++ b/lib/listen/adapter/bsd.rb
@@ -7,7 +7,7 @@
 module Listen
   module Adapter
     class BSD < Base
-      OS_REGEXP = /bsd|dragonfly/i.freeze
+      OS_REGEXP = /bsd|dragonfly/i
 
       DEFAULTS = {
         events: [

--- a/lib/listen/adapter/darwin.rb
+++ b/lib/listen/adapter/darwin.rb
@@ -7,7 +7,7 @@ module Listen
     # Adapter implementation for Mac OS X `FSEvents`.
     #
     class Darwin < Base
-      OS_REGEXP = /darwin(?<major_version>(1|2)\d+)/i.freeze
+      OS_REGEXP = /darwin(?<major_version>(1|2)\d+)/i
 
       # The default delay between checking for changes.
       DEFAULTS = { latency: 0.1 }.freeze

--- a/lib/listen/adapter/linux.rb
+++ b/lib/listen/adapter/linux.rb
@@ -4,7 +4,7 @@ module Listen
   module Adapter
     # @see https://github.com/nex3/rb-inotify
     class Linux < Base
-      OS_REGEXP = /linux/i.freeze
+      OS_REGEXP = /linux/i
 
       DEFAULTS = {
         events: [

--- a/lib/listen/adapter/linux.rb
+++ b/lib/listen/adapter/linux.rb
@@ -60,7 +60,7 @@ module Listen
 
         cookie_params = event.cookie.zero? ? {} : { cookie: event.cookie }
 
-        # Note: don't pass options to force rescanning the directory, so we can
+        # NOTE: don't pass options to force rescanning the directory, so we can
         # detect moving/deleting a whole tree
         if _dir_event?(event)
           _queue_change(:dir, dir, rel_path, cookie_params)

--- a/lib/listen/adapter/polling.rb
+++ b/lib/listen/adapter/polling.rb
@@ -8,7 +8,7 @@ module Listen
     # file IO than the other implementations.
     #
     class Polling < Base
-      OS_REGEXP = //.freeze # match every OS
+      OS_REGEXP = // # match every OS
 
       DEFAULTS = { latency: 1.0, wait_for_delay: 0.05 }.freeze
 

--- a/lib/listen/adapter/windows.rb
+++ b/lib/listen/adapter/windows.rb
@@ -5,7 +5,7 @@ module Listen
     # Adapter implementation for Windows `wdm`.
     #
     class Windows < Base
-      OS_REGEXP = /mswin|mingw|cygwin/i.freeze
+      OS_REGEXP = /mswin|mingw|cygwin/i
 
       BUNDLER_DECLARE_GEM = <<-EOS.gsub(/^ {6}/, '')
         Please add the following to your Gemfile to avoid polling for changes:

--- a/lib/listen/event/processor.rb
+++ b/lib/listen/event/processor.rb
@@ -85,11 +85,13 @@ module Listen
 
       # blocks until event is popped
       # returns the event or `nil` when the event_queue is closed
+      # rubocop:disable Naming/MemoizedInstanceVariableName
       def _wait_until_events
         config.event_queue.pop.tap do |_event|
           @_remember_time_of_first_unprocessed_event ||= MonotonicTime.now
         end
       end
+      # rubocop:enable Naming/MemoizedInstanceVariableName
 
       def _flush_wakeup_reasons
         until @reasons.empty?

--- a/lib/listen/fsm.rb
+++ b/lib/listen/fsm.rb
@@ -38,7 +38,7 @@ module Listen
       end
     end
 
-    # Note: including classes must call initialize_fsm from their initialize method.
+    # NOTE: including classes must call initialize_fsm from their initialize method.
     def initialize_fsm
       @fsm_initialized = true
       @state = self.class.start_state

--- a/lib/listen/options.rb
+++ b/lib/listen/options.rb
@@ -12,7 +12,6 @@ module Listen
       given_options.empty? or raise ArgumentError, "Unknown options: #{given_options.inspect}"
     end
 
-    # rubocop:disable Lint/MissingSuper
     def respond_to_missing?(name, *_)
       @options.has_key?(name)
     end
@@ -21,6 +20,5 @@ module Listen
       respond_to_missing?(name) or raise NameError, "Bad option: #{name.inspect} (valid:#{@options.keys.inspect})"
       @options[name]
     end
-    # rubocop:enable Lint/MissingSuper
   end
 end

--- a/lib/listen/record.rb
+++ b/lib/listen/record.rb
@@ -73,7 +73,7 @@ module Listen
     private
 
     def empty_dirname?(dirname)
-      dirname == '.' || dirname == ''
+      ['.', ''].include?(dirname)
     end
 
     def reset_tree

--- a/lib/listen/record/symlink_detector.rb
+++ b/lib/listen/record/symlink_detector.rb
@@ -9,7 +9,7 @@ module Listen
     class SymlinkDetector
       README_URL = 'https://github.com/guard/listen/blob/master/README.md'
 
-      SYMLINK_LOOP_ERROR = <<-EOS
+      SYMLINK_LOOP_ERROR = <<-EOS.freeze
         ** ERROR: directory is already being watched! **
 
         Directory: %s

--- a/lib/listen/silencer.rb
+++ b/lib/listen/silencer.rb
@@ -18,7 +18,7 @@ module Listen
       # emacs temp files
       | \#.+\#
       | \.\#.+
-      )(/|\z)}x.freeze
+      )(/|\z)}x
 
     # The default list of files that get ignored.
     DEFAULT_IGNORED_EXTENSIONS = %r{(?:
@@ -59,7 +59,7 @@ module Listen
       | \.DS_Store
       | \.tmp
       | ~
-    )\z}x.freeze
+    )\z}x
 
     # TODO: deprecate these mutators; use attr_reader instead
     attr_accessor :only_patterns, :ignore_patterns


### PR DESCRIPTION
Fix #516 

Rubocop version `0.91` specified in the Gemfile isn't working for Ruby 3+ and the rake task fails locally.
Upgrading Rubocop solves the problem. 
I thought I'd take the opportunity to fix #516 since it's an open issue.