### PR TITLE
Replace Kernel warnings with Listen.logger

### DIFF
--- a/lib/listen/adapter.rb
+++ b/lib/listen/adapter.rb
@@ -36,7 +36,7 @@ module Listen
 
       def _warn_polling_fallback(options)
         msg = options.fetch(:polling_fallback_message, POLLING_FALLBACK_MESSAGE)
-        Listen.logger.warn "[Listen warning]:\n  #{msg}" if msg
+        Listen.logger.warn(msg) if msg
       end
     end
   end

--- a/lib/listen/adapter.rb
+++ b/lib/listen/adapter.rb
@@ -36,7 +36,7 @@ module Listen
 
       def _warn_polling_fallback(options)
         msg = options.fetch(:polling_fallback_message, POLLING_FALLBACK_MESSAGE)
-        Kernel.warn "[Listen warning]:\n  #{msg}" if msg
+        Listen.logger.warn "[Listen warning]:\n  #{msg}" if msg
       end
     end
   end

--- a/lib/listen/adapter/bsd.rb
+++ b/lib/listen/adapter/bsd.rb
@@ -34,7 +34,7 @@ module Listen
         require 'find'
         true
       rescue LoadError
-        Kernel.warn BUNDLER_DECLARE_GEM
+        Listen.logger.warn BUNDLER_DECLARE_GEM
         false
       end
 

--- a/lib/listen/adapter/darwin.rb
+++ b/lib/listen/adapter/darwin.rb
@@ -30,7 +30,7 @@ module Listen
         require 'rb-fsevent'
         fsevent_version = Gem::Version.new(FSEvent::VERSION)
         return true if fsevent_version <= Gem::Version.new('0.9.4')
-        Kernel.warn INCOMPATIBLE_GEM_VERSION
+        Listen.logger.warn INCOMPATIBLE_GEM_VERSION
         false
       end
 

--- a/lib/listen/adapter/windows.rb
+++ b/lib/listen/adapter/windows.rb
@@ -20,7 +20,7 @@ module Listen
         Listen.logger.debug format('wdm - load failed: %s:%s', $ERROR_INFO,
                                    $ERROR_POSITION * "\n")
 
-        Kernel.warn BUNDLER_DECLARE_GEM
+        Listen.logger.warn BUNDLER_DECLARE_GEM
         false
       end
 

--- a/lib/listen/record/symlink_detector.rb
+++ b/lib/listen/record/symlink_detector.rb
@@ -33,7 +33,7 @@ module Listen
       private
 
       def _fail(symlinked, real_path)
-        warn(format(SYMLINK_LOOP_ERROR, symlinked, real_path))
+        Listen.logger.warn(format(SYMLINK_LOOP_ERROR, symlinked, real_path))
         raise ::Listen::Error::SymlinkLoop, 'Failed due to looped symlinks'
       end
     end

--- a/spec/lib/listen/adapter/darwin_spec.rb
+++ b/spec/lib/listen/adapter/darwin_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Adapter::Darwin do
       context 'with rb-fsevent > 0.9.4' do
         before { stub_const('FSEvent::VERSION', '0.9.6') }
         it 'shows a warning and should not be usable' do
-          expect(Kernel).to receive(:warn)
+          expect(Listen.logger).to receive(:warn)
           expect(subject).to_not be_usable
         end
       end

--- a/spec/lib/listen/adapter_spec.rb
+++ b/spec/lib/listen/adapter_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Listen::Adapter do
     end
 
     context 'no usable adapters' do
-      before { allow(Kernel).to receive(:warn) }
+      before { allow(Listen.logger).to receive(:warn) }
 
       it 'returns Polling adapter' do
         klass = Listen::Adapter.select(force_polling: true)
@@ -49,18 +49,18 @@ RSpec.describe Listen::Adapter do
 
       it 'warns polling fallback with default message' do
         msg = described_class::POLLING_FALLBACK_MESSAGE
-        expect(Kernel).to receive(:warn).with("[Listen warning]:\n  #{msg}")
+        expect(Listen.logger).to receive(:warn).with("[Listen warning]:\n  #{msg}")
         Listen::Adapter.select
       end
 
       it "doesn't warn if polling_fallback_message is false" do
-        expect(Kernel).to_not receive(:warn)
+        expect(Listen.logger).to_not receive(:warn)
         Listen::Adapter.select(polling_fallback_message: false)
       end
 
       it 'warns polling fallback with custom message if set' do
         expected_msg = "[Listen warning]:\n  custom fallback message"
-        expect(Kernel).to receive(:warn).with(expected_msg)
+        expect(Listen.logger).to receive(:warn).with(expected_msg)
         msg = 'custom fallback message'
         Listen::Adapter.select(polling_fallback_message: msg)
       end

--- a/spec/lib/listen/adapter_spec.rb
+++ b/spec/lib/listen/adapter_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Listen::Adapter do
 
       it 'warns polling fallback with default message' do
         msg = described_class::POLLING_FALLBACK_MESSAGE
-        expect(Listen.logger).to receive(:warn).with("[Listen warning]:\n  #{msg}")
+        expect(Listen.logger).to receive(:warn).with(msg)
         Listen::Adapter.select
       end
 
@@ -59,7 +59,7 @@ RSpec.describe Listen::Adapter do
       end
 
       it 'warns polling fallback with custom message if set' do
-        expected_msg = "[Listen warning]:\n  custom fallback message"
+        expected_msg = "custom fallback message"
         expect(Listen.logger).to receive(:warn).with(expected_msg)
         msg = 'custom fallback message'
         Listen::Adapter.select(polling_fallback_message: msg)

--- a/spec/lib/listen/record_spec.rb
+++ b/spec/lib/listen/record_spec.rb
@@ -375,7 +375,7 @@ RSpec.describe Listen::Record do
       end
 
       it 'shows a warning' do
-        expect_any_instance_of(Listen::Record::SymlinkDetector).to receive(:warn).
+        expect(Listen.logger).to receive(:warn).
           with(/directory is already being watched/)
 
         record.build


### PR DESCRIPTION
Fix #572 

In case we can move these calls to Listen.logger here is the PR for the change.