### PR TITLE
Fix github workflows link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The `listen` gem listens to file modifications and notifies you about the change
 * You can watch multiple directories.
 * Regexp-patterns for ignoring paths for more accuracy and speed
 * Increased change detection accuracy on OS X HFS and VFAT volumes.
-* Continuous Integration: tested on selected Ruby environments via [Github Workflows](https:///github.com/guard/listen/master/.github/workflows).
+* Continuous Integration: tested on selected Ruby environments via [Github Workflows](https://github.com/guard/listen/tree/master/.github/workflows).
 
 ## Issues / limitations
 


### PR DESCRIPTION
The link was a 404 and has been corrected.