### PR TITLE
Add `logger` as a runtime dependency

### DIFF
--- a/listen.gemspec
+++ b/listen.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |gem| # rubocop:disable Metrics/BlockLength
 
   gem.required_ruby_version = '>= 2.4.0' # rubocop:disable Gemspec/RequiredRubyVersion
 
+  gem.add_dependency 'logger'
   gem.add_dependency 'rb-fsevent', '~> 0.10', '>= 0.10.3'
   gem.add_dependency 'rb-inotify', '~> 0.9', '>= 0.9.10'
 end


### PR DESCRIPTION
Ruby continues its path of extracting gems.
Not specifying this in Ruby 3.4 will warn, in 3.5 it errors

https://github.com/ruby/ruby/commit/d7e558e3c48c213d0e8bedca4fb547db55613f7c