### PR TITLE
Update used GitHub actions

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -39,7 +39,7 @@ jobs:
             experimental: true
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{matrix.ruby}}
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,8 +5,8 @@ jobs:
     name: Draft Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Draft Release
-        uses: toolmantim/release-drafter@v5.2.0
+        uses: toolmantim/release-drafter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
They show deprecation notices for old Node versions.

There are no relevant breaking changes between these major versions, except for the bump of node.
* https://github.com/release-drafter/release-drafter/releases/tag/v6.0.0
* https://github.com/actions/checkout/releases/tag/v4.0.0
* https://github.com/actions/checkout/releases/tag/v3.0.0

https://github.com/guard/listen/actions/runs/8075253923
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2.

![image](https://github.com/guard/listen/assets/14981592/efc94fab-1962-479e-8e0c-fa52bd7dfa23)
