### PR TITLE
Remove conditions from gem declarations in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,14 +11,8 @@ else
   gemspec development_group: :gem_build_tools
 end
 
-require 'rbconfig'
-
-case RbConfig::CONFIG['target_os']
-when /mswin|mingw|cygwin/i
-  gem 'wdm', '>= 0.1.0'
-when /bsd|dragonfly/i
-  gem 'rb-kqueue', '>= 0.2'
-end
+gem 'rb-kqueue', '>= 0.2'
+gem 'wdm', '>= 0.1.0'
 
 group :test do
   gem 'coveralls'

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ If you are on Windows, it's recommended to use the [`wdm`](https://github.com/Ma
 Please add the following to your Gemfile:
 
 ```ruby
-gem 'wdm', '>= 0.1.0', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'wdm', '>= 0.1.0'
 ```
 
 ### On \*BSD
@@ -275,11 +275,7 @@ If you are on \*BSD you can try to use the [`rb-kqueue`](https://github.com/mat8
 Please add the following to your Gemfile:
 
 ```ruby
-require 'rbconfig'
-if RbConfig::CONFIG['target_os'] =~ /bsd|dragonfly/i
-  gem 'rb-kqueue', '>= 0.2'
-end
-
+gem 'rb-kqueue', '>= 0.2'
 ```
 
 ### Getting the [polling fallback message](#options)?

--- a/lib/listen/adapter/bsd.rb
+++ b/lib/listen/adapter/bsd.rb
@@ -22,10 +22,7 @@ module Listen
 
       BUNDLER_DECLARE_GEM = <<-EOS.gsub(/^ {6}/, '')
         Please add the following to your Gemfile to avoid polling for changes:
-          require 'rbconfig'
-          if RbConfig::CONFIG['target_os'] =~ /#{OS_REGEXP}/
-            gem 'rb-kqueue', '>= 0.2'
-          end
+          gem 'rb-kqueue', '>= 0.2'
       EOS
 
       def self.usable?

--- a/lib/listen/adapter/windows.rb
+++ b/lib/listen/adapter/windows.rb
@@ -9,7 +9,7 @@ module Listen
 
       BUNDLER_DECLARE_GEM = <<-EOS.gsub(/^ {6}/, '')
         Please add the following to your Gemfile to avoid polling for changes:
-          gem 'wdm', '>= 0.1.0' if Gem.win_platform?
+          gem 'wdm', '>= 0.1.0'
       EOS
 
       def self.usable?


### PR DESCRIPTION
Both gems 'wdm' and 'rb-kqueue' can be installed on any platform. They fail when require 'wdm' or 'rb-kqueue' is called. So the conditions in the Gemfile can be removed and should not be recommended.

Having conditions in the Gemfile is generally bad practice, since this leads to changed Gemfile.lock, whenever the bundler is executed on a different platform. Also `bundle package --all-platforms` doesn't work properly, when gems are declared conditionally.