### PR TITLE
CI: Run all tests on Windows in addition

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -13,6 +13,7 @@ jobs:
         os:
           - ubuntu
           - macos
+          - windows
 
         ruby:
           - 2.7

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The `listen` gem listens to file modifications and notifies you about the change
 * Support for plugins planned for future.
 * TCP functionality was removed in `listen` [3.0.0](https://github.com/guard/listen/releases/tag/v3.0.0) ([#319](https://github.com/guard/listen/issues/319), [#218](https://github.com/guard/listen/issues/218)). There are plans to extract this feature to separate gems ([#258](https://github.com/guard/listen/issues/258)), until this is finished, you can use by locking the `listen` gem to version `'~> 2.10'`.
 * Some filesystems won't work without polling (VM/Vagrant Shared folders, NFS, Samba, sshfs, etc.).
-* Windows and \*BSD adapter aren't continuously and automatically tested.
+* \*BSD adapter isn't continuously and automatically tested.
 * OSX adapter has some performance limitations ([#342](https://github.com/guard/listen/issues/342)).
 * Listeners do not notify across forked processes, if you wish for multiple processes to receive change notifications you must [listen inside of each process](https://github.com/guard/listen/issues/398#issuecomment-223957952).
 


### PR DESCRIPTION
I don't see a reason to not test on Windows. All tests pass out of the box with the wdm adapter.