### PR TITLE
Fix the Rubocop offence

### DIFF
--- a/lib/listen/event/config.rb
+++ b/lib/listen/event/config.rb
@@ -12,7 +12,6 @@ module Listen
         wait_for_delay,
         &block
       )
-
         @listener = listener
         @event_queue = event_queue
         @queue_optimizer = queue_optimizer


### PR DESCRIPTION
This PR fixes the following offence.

```
lib/listen/event/config.rb:15:1: C: [Correctable] Layout/EmptyLinesAroundMethodBody: Extra empty line detected at method body beginning.
```

Ref: https://github.com/guard/listen/actions/runs/12850558185/job/35830361327?pr=587