### PR TITLE
CI against Ruby 3.4

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -20,6 +20,7 @@ jobs:
           - 3.1
           - 3.2
           - 3.3
+          - 3.4
 
         experimental: [false]
         env: [""]


### PR DESCRIPTION
This PR just adds the Ruby 3.4 to the CI matrix to check `listen` works with it.