### PR TITLE
Preserve independent listener filters across updates

### DIFF
--- a/lib/listen/silencer/controller.rb
+++ b/lib/listen/silencer/controller.rb
@@ -17,16 +17,21 @@ module Listen
       end
 
       def append_ignores(*regexps)
-        prev_ignores = Array(@prev_silencer_options[:ignore])
-        _reconfigure_silencer(ignore: [prev_ignores + regexps])
+        opts = @prev_silencer_options.dup
+        opts[:ignore] = [opts[:ignore], regexps]
+        _reconfigure_silencer(opts)
       end
 
       def replace_with_bang_ignores(regexps)
-        _reconfigure_silencer(ignore!: regexps)
+        opts = @prev_silencer_options.dup
+        opts.delete(:ignore)
+        opts[:ignore!] = regexps
+        _reconfigure_silencer(opts)
       end
 
       def replace_with_only(regexps)
-        _reconfigure_silencer(only: regexps)
+        opts = @prev_silencer_options.merge(only: regexps)
+        _reconfigure_silencer(opts)
       end
 
       private


### PR DESCRIPTION
Summary

Keep only, ignore, and ignore! state independent when filters are updated dynamically. This preserves the README contract that ignore adds to an existing ignore! override and prevents one filter update from discarding unrelated active state.

Reproduction

After configuring ignore! and then adding ignore, the current controller loses the override. Updating only also discards existing ignore state. The standalone model fails on 3.10.0 with the lost ignore! rule and passes with this change.

Verification

- Full suite: 393 examples, zero failures, one existing pending
- Focused filter suite: 105 examples, zero failures
- External dynamic-filter model passes
- RuboCop: 68 files, no offenses
- Candidate gem builds with unchanged packaged file list
- Rails development boot composes ActiveSupport::EventedFileUpdateChecker with the candidate
- Release/current upstream workflows are green

No tests were changed. This source-only patch was identified and verified during an AI-assisted dependency audit.