### PR TITLE
Avoid selecting the filesystem adapter twice

### DIFF
--- a/lib/listen/adapter.rb
+++ b/lib/listen/adapter.rb
@@ -18,7 +18,8 @@ module Listen
         Listen.logger.debug 'Adapter: considering polling ...'
         return Polling if options[:force_polling]
         Listen.logger.debug 'Adapter: considering optimized backend...'
-        return _usable_adapter_class if _usable_adapter_class
+        adapter_class = _usable_adapter_class
+        return adapter_class if adapter_class
         Listen.logger.debug 'Adapter: falling back to polling...'
         _warn_polling_fallback(options)
         Polling


### PR DESCRIPTION
Summary

Cache the successful adapter discovery in Adapter.select so the availability scan runs once instead of repeating immediately.

Reproduction

The current return expression calls _usable_adapter_class once for the condition and again for the returned value. A focused external model observes two discovery calls on 3.10.0 and one with this change.

Verification

- Full suite: 393 examples, zero failures, one existing pending
- Focused adapter suite: 9 examples, zero failures
- External call-count model passes
- RuboCop: 68 files, no offenses
- Candidate gem builds with unchanged packaged file list
- Rails development boot composes ActiveSupport::EventedFileUpdateChecker with the candidate
- Release/current upstream workflows are green

No tests were changed. This source-only patch was identified and verified during an AI-assisted dependency audit.