### PR TITLE
[LOW] Bound directory scanning under filesystem churn

### DIFF
--- a/lib/listen/change.rb
+++ b/lib/listen/change.rb
@@ -55,9 +55,7 @@ module Listen
         options = cookie ? { cookie: cookie } : {}
         @config.queue(type, change, watched_dir, rel_path, options)
       elsif type == :dir
-        # NOTE: POSSIBLE RECURSION
-        # TODO: fix - use a queue instead
-        Directory.scan(self, rel_path, options)
+        _scan_directory(rel_path, options)
       elsif (change = File.change(record, rel_path)) && !options[:silence]
         @config.queue(:file, change, watched_dir, rel_path)
       end
@@ -65,5 +63,25 @@ module Listen
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/PerceivedComplexity
+
+    private
+
+    def _scan_directory(rel_path, options)
+      @directory_scan_queue ||= []
+      @directory_scan_queue << [rel_path, options]
+      return if @scanning_directories
+
+      _drain_directory_scan_queue
+    end
+
+    def _drain_directory_scan_queue
+      @scanning_directories = true
+      @directory_scan_queue.each do |path, options|
+        Directory.scan(self, path, options)
+      end
+    ensure
+      @directory_scan_queue.clear
+      @scanning_directories = false
+    end
   end
 end

--- a/lib/listen/directory.rb
+++ b/lib/listen/directory.rb
@@ -5,6 +5,8 @@ require 'set'
 module Listen
   # TODO: refactor (turn it into a normal object, cache the stat, etc)
   class Directory
+    MAX_RESCAN_ATTEMPTS = 5
+
     # rubocop:disable Metrics/MethodLength
     def self.scan(snapshot, rel_path, options)
       record = snapshot.record
@@ -23,6 +25,8 @@ module Listen
                rel_path, options.inspect, previous.inspect, current.inspect)
       end
 
+      rescan_attempts = 0
+      full_path = nil
       begin
         current.each do |full_path|
           type = ::File.lstat(full_path.to_s).directory? ? :dir : :file
@@ -31,8 +35,16 @@ module Listen
         end
       rescue Errno::ENOENT
         # The directory changed meanwhile, so rescan it
-        current = Set.new(_children(path))
-        retry
+        rescan_attempts += 1
+        if rescan_attempts <= MAX_RESCAN_ATTEMPTS
+          current = Set.new(_children(path))
+          retry
+        end
+
+        current.delete(full_path)
+        Listen.logger.debug do
+          "scan remained unstable after #{MAX_RESCAN_ATTEMPTS} rescans: #{path}"
+        end
       end
 
       # TODO: this is not tested properly
@@ -48,7 +60,9 @@ module Listen
       _async_changes(snapshot, path, previous, options)
       _change(snapshot, :file, rel_path, options)
     rescue
-      Listen.logger.warn { format('scan DIED: %s:%s', $ERROR_INFO, $ERROR_POSITION * "\n") }
+      Listen.logger.warn do
+        "scan DIED: #{$ERROR_INFO}:#{$ERROR_POSITION * "\n"}"
+      end
       raise
     end
     # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
## Security impact (LOW)

A process that can create entries inside a watched directory can make directory scanning consume unbounded listener work in two ways:

- Deep directory trees are processed through recursive `Change#invalidate` calls. A modeled depth of 1,794 raises `SystemStackError`, which the listener thread deliberately does not rescue.
- If an entry disappears between enumeration and `lstat`, `Directory.scan` restarts without a limit. A deterministic unstable-directory model performed 118,349 rescans in 50 ms and did not return.

Both require local write influence over a directory the application chose to watch. The impact is loss of file-watch processing rather than code execution or data disclosure, so the urgency is low.

## Fix

- Queue nested directory scans on the existing `Change` instance and drain them iteratively.
- Limit a single unstable scan to five retries, then discard the vanished entry and let the next filesystem event or polling pass reconcile the tree.
- Preserve filtering, event queuing, normal scan behavior, and public APIs.

## Reproduction and verification

- Baseline deep-tree model: `SystemStackError` at depth 1,794.
- Patched deep-tree model: completes at depth 2,000 without recursion failure.
- Baseline churn model: times out after 118,349 rescans in 50 ms.
- Patched churn model: completes after the initial scan plus five retries.
- Each runtime commit independently passes the full suite: 393 examples, 0 failures, 1 existing pending example on Ruby 4.0.6/macOS.
- Combined branch: 335 unit examples, 0 failures, 1 existing pending; 68 RuboCop files with no offenses; all runtime syntax checks, gem build, and `git diff --check` pass.

No test files are changed.

## Limitations

This bounds work performed by one scan. A caller that deliberately configures polling over a very large or continuously changing tree can still create sustained filesystem load and should use normal directory scoping and ignore rules. Native Linux/BSD/Windows adapters and network filesystems were not exercised locally.

## Breaking changes

None. Under continuous churn, reconciliation may be deferred to the next event after five failed rescans instead of monopolizing the listener indefinitely.
