### PR TITLE
[LOW] Pin workflow actions and token permissions

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -2,6 +2,9 @@ name: Development
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{matrix.os}}-latest
@@ -41,8 +44,8 @@ jobs:
             experimental: true
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
+    - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
       with:
         ruby-version: ${{matrix.ruby}}
         bundler-cache: true
@@ -56,8 +59,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
+    - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
       with:
         ruby-version: 3.2
         bundler-cache: true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,9 +4,12 @@ jobs:
   draftRelease:
     name: Draft Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
       - name: Draft Release
-        uses: toolmantim/release-drafter@v5.2.0
+        uses: release-drafter/release-drafter@abe0a97533ba1903c8028891ff4fd7e0083ccc72 # v5.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Security impact (LOW)

Development and release workflows execute mutable action tags/branches. The release job also passes `GITHUB_TOKEN` to Release Drafter without an explicit job permission boundary. If a referenced channel moves unexpectedly or an action repository is compromised, changed third-party code can run during CI or release drafting with the workflow token's ambient access.

This requires an upstream action compromise or malicious reference movement, so the urgency is low.

## Fix

- Pin the exact revisions currently resolved by checkout v2/master, setup-ruby v1, and Release Drafter v5.2.0.
- Use Release Drafter's current canonical repository name after its transfer.
- Set development jobs to `contents: read`.
- Restrict the release-drafting job to `contents: write` and `pull-requests: read`.

## Verification

- Both workflow YAML documents parse successfully.
- Every `uses:` entry is pinned to a full 40-character commit.
- The existing runtime suite passes 393 examples with 0 failures and 1 existing pending example on Ruby 4.0.6/macOS.
- `git diff --check` passes.

`actionlint` was not available locally; upstream Actions is the authoritative workflow runner validation.

## Breaking changes

Workflow action updates now require deliberate SHA changes. Runtime and gem behavior are unchanged.
